### PR TITLE
Fix: enums should be considered value types

### DIFF
--- a/XObjectsCode/Src/ClrTypeInfo.cs
+++ b/XObjectsCode/Src/ClrTypeInfo.cs
@@ -500,7 +500,7 @@ namespace Xml.Schema.Linq.CodeGen
 
                 if (st.IsEnum())
                 {
-                    typeRefFlags |= ClrTypeRefFlags.IsEnum;
+                    typeRefFlags |= ClrTypeRefFlags.IsEnum | ClrTypeRefFlags.IsValueType;
                 }
 
                 XmlSchemaDatatype datatype = st.Datatype;


### PR DESCRIPTION
Fixes #20 

The problem was that enums are strings with restrictions in the XSD, and because string is a ref type, this evaluated to false in ClrTypeInfo (514):
```cs
                if (datatype.ValueType.IsValueType)
                {
                    typeRefFlags |= ClrTypeRefFlags.IsValueType;
                }
```

So I made sure `ClrTypeInfo` considers enums as value types as well, which only seem to impact `ClrPropertyInfo` codegen.

I did a before/after on the large _pain.002.001.03.xsd_ that I referred to in my bug report.

The only differences are optional / choice enum properties, which now look like this:
![image](https://user-images.githubusercontent.com/3832820/106797814-66588100-665d-11eb-8c9b-1f9e4cd0cbeb.png)

This is perfectly in line with the codegen for similar value types such as `DateTime` (unchanged):
```cs
        /// <summary>
        /// <para>
        /// Occurrence: optional
        /// </para>
        /// <para>
        /// Regular expression: (Tp?, Nb?, RltdDt?)
        /// </para>
        /// </summary>
        public virtual System.Nullable<System.DateTime> RltdDt {
            get {
                XElement x = this.GetElement(System.Xml.Linq.XName.Get("RltdDt", "urn:iso:std:iso:20022:tech:xsd:pain.002.001.03"));
                if ((x == null)) {
                    return null;
                }
                return XTypedServices.ParseValue<System.DateTime>(x, XmlSchemaType.GetBuiltInSimpleType(XmlTypeCode.Date).Datatype);
            }
            set {
                this.SetElementWithValidation(System.Xml.Linq.XName.Get("RltdDt", "urn:iso:std:iso:20022:tech:xsd:pain.002.001.03"), value, "RltdDt", global::Iso20022.Pain_002_001_03.ISODate.TypeDefinition);
            }
        }
```

I'm attaching the schema and a before/after for your convenience.
[Test.zip](https://github.com/mamift/LinqToXsdCore/files/5920937/Test.zip)