### PR TITLE
Cache XNames

### DIFF
--- a/XObjectsCode/Src/CodeDomHelper.cs
+++ b/XObjectsCode/Src/CodeDomHelper.cs
@@ -236,15 +236,6 @@ namespace Xml.Schema.Linq.CodeGen
             return property;
         }
 
-        public static CodeMemberProperty CreateSchemaNameProperty(string schemaName, string schemaNs,
-            MemberAttributes attributes)
-        {
-            CodeMemberProperty property = CreateInterfaceImplProperty(Constants.SchemaName, Constants.IXMetaData,
-                new CodeTypeReference(Constants.XNameType), attributes);
-            property.GetStatements.Add(new CodeMethodReturnStatement(XNameGetExpression(schemaName, schemaNs)));
-            return property;
-        }
-
         public static CodeMemberProperty CreateTypeOriginProperty(SchemaOrigin typeOrigin,
             MemberAttributes visibility)
         {

--- a/XObjectsCode/Src/Enums.cs
+++ b/XObjectsCode/Src/Enums.cs
@@ -94,6 +94,7 @@ namespace Xml.Schema.Linq.CodeGen
         MakeUnion,
         MakeDefaultValueField,
         MakeFixedValueField,
+        MakeXName,
     }
 
     internal enum ContentType

--- a/XObjectsCode/Src/NameMangler.cs
+++ b/XObjectsCode/Src/NameMangler.cs
@@ -75,6 +75,9 @@ namespace Xml.Schema.Linq.CodeGen
 
                 case NameOptions.MakeDefaultValueField:
                     return clrName + "DefaultValue";
+
+                case NameOptions.MakeXName:
+                    return clrName + "XName";
             }
 
             return clrName;

--- a/XObjectsCode/Src/TypeBuilder.cs
+++ b/XObjectsCode/Src/TypeBuilder.cs
@@ -253,12 +253,28 @@ namespace Xml.Schema.Linq.CodeGen
             //Do nothing, this will inherit the LocalElementDictionary from XTypedElement which returns empty dict and Content which returns null
         }
 
+        public CodeMemberProperty CreateSchemaNameProperty(string schemaName, string schemaNs, MemberAttributes attributes)
+        {
+            // HACK: CodeDom doesn't model readonly fields... but it doesn't check the type either!
+            var field = new CodeMemberField("readonly string", "xName")
+            {
+                Attributes = MemberAttributes.Private | MemberAttributes.Static,
+                InitExpression = CodeDomHelper.XNameGetExpression(schemaName, schemaNs),
+            };
+            decl.Members.Add(field);
+
+            CodeMemberProperty property = CodeDomHelper.CreateInterfaceImplProperty(Constants.SchemaName, Constants.IXMetaData,
+                new CodeTypeReference(Constants.XNameType), attributes);
+            property.GetStatements.Add(new CodeMethodReturnStatement(new CodeFieldReferenceExpression(null, "xName")));
+            return property;
+        }
+
         private void ImplementIXMetaData()
         {
             string interfaceName = Constants.IXMetaData;
 
             CodeMemberProperty schemaNameProperty =
-                CodeDomHelper.CreateSchemaNameProperty(clrTypeInfo.schemaName, clrTypeInfo.schemaNs, DefaultVisibility.ToMemberAttribute());
+                CreateSchemaNameProperty(clrTypeInfo.schemaName, clrTypeInfo.schemaNs, DefaultVisibility.ToMemberAttribute());
 
             ImplementCommonIXMetaData();
             if (clrTypeInfo.HasElementWildCard) ImplementFSMMetaData();

--- a/XObjectsCode/Src/TypeBuilder.cs
+++ b/XObjectsCode/Src/TypeBuilder.cs
@@ -784,7 +784,7 @@ namespace Xml.Schema.Linq.CodeGen
                 //Do not add repeating properties to the LocalElementDictionary of type
                 propertyDictionaryAddStatements.Add(CodeDomHelper.CreateMethodCallFromField(
                     Constants.LocalElementDictionaryField, "Add",
-                    CodeDomHelper.XNameGetExpression(propertyInfo.SchemaName, propertyInfo.PropertyNs),
+                    propertyInfo.GetXName(),
                     CodeDomHelper.Typeof(propertyInfo.ClrTypeName)));
             }
         }


### PR DESCRIPTION
Fixes #19 

This contains two commits. 

The first caches XName lookups for ClrPropertyInfo. This replaces the codegen of 4 XName.Get calls with a single one: (1) getter, (2) setter, (3) code model in ctor, (4) local types dictionary.
(1) and (2) are esp. interesting because they can be in hot paths if you're processing a lot of large documents.

The second caches the single `IXMetaData.SchemaName` lookup. This one is called _a lot_ during document processing so it's worth avoiding the expensive `XName` lookup.

One could try to improve the codegen further by reusing the `SchemaName` cache for `ClrPropertyInfo` or getting rid of the XName lookups in the global types dictionary. Those tasks are more complex and have virtually no runtime benefit so I stopped here.

For your convenience, I have attached a before/after of one of my schemas.
[test.zip](https://github.com/mamift/LinqToXsdCore/files/5921734/test.zip)
