### PR TITLE
Fix: can't pass null to a setter with validation

### DIFF
--- a/XObjectsCode/Src/ClrPropertyInfo.cs
+++ b/XObjectsCode/Src/ClrPropertyInfo.cs
@@ -948,7 +948,8 @@ namespace Xml.Schema.Linq.CodeGen
             }
             else
             {
-                setStatements.Add(CreatePlainSetCall(setMethodName, IsEnum ? "value.ToString()" : "value", xNameParm));
+                var valueExpr = !IsEnum ? "value" : IsNullable ? "value?.ToString()" : "value.ToString()";
+                setStatements.Add(CreatePlainSetCall(setMethodName, valueExpr, xNameParm));
             }
         }
 

--- a/XObjectsCode/Src/ClrPropertyInfo.cs
+++ b/XObjectsCode/Src/ClrPropertyInfo.cs
@@ -843,17 +843,16 @@ namespace Xml.Schema.Linq.CodeGen
             }
         }
 
-        private CodeMethodInvokeExpression SetValueMethodCall()
-        {
-            CodeMethodInvokeExpression methodCall = null;
+        private void AddSetValueMethodCall(CodeStatementCollection setStatements)
+        {            
             string setMethodName = "Set";
             if (!IsRef && IsSchemaList)
             {
-                setMethodName = string.Concat(setMethodName, "List");
+                setMethodName = "SetList";
             }
             else if (IsUnion)
             {
-                setMethodName = string.Concat(setMethodName, "Union");
+                setMethodName = "SetUnion";
             }
 
             bool validation = Validation;
@@ -861,16 +860,16 @@ namespace Xml.Schema.Linq.CodeGen
             switch (propertyOrigin)
             {
                 case SchemaOrigin.Element:
-                    setMethodName = string.Concat(setMethodName, "Element");
+                    setMethodName += "Element";
                     break;
 
                 case SchemaOrigin.Attribute:
                     validation = false;
-                    setMethodName = string.Concat(setMethodName, "Attribute");
+                    setMethodName += "Attribute";
                     break;
 
                 case SchemaOrigin.Text:
-                    setMethodName = string.Concat(setMethodName, "Value");
+                    setMethodName += "Value";
                     xNameParm = false;
                     break;
 
@@ -883,30 +882,40 @@ namespace Xml.Schema.Linq.CodeGen
             {
                 if (xNameParm)
                 {
-                    methodCall = CodeDomHelper.CreateMethodCall(CodeDomHelper.This(), setMethodName,
-                        CodeDomHelper.SetValue(),
-                        new CodePrimitiveExpression(this.propertyName),
-                        CodeDomHelper.This(),
-                        xNameExpression,
-                        GetSimpleTypeClassExpression());
+                    setStatements.Add(
+                        CodeDomHelper.CreateMethodCall(
+                            CodeDomHelper.This(), 
+                            setMethodName,
+                            CodeDomHelper.SetValue(),
+                            new CodePrimitiveExpression(this.propertyName),
+                            CodeDomHelper.This(),
+                            xNameExpression,
+                            GetSimpleTypeClassExpression())
+                    );
                 }
                 else
                 {
-                    methodCall = CodeDomHelper.CreateMethodCall(CodeDomHelper.This(), setMethodName,
-                        CodeDomHelper.SetValue(),
-                        new CodePrimitiveExpression(this.propertyName),
-                        CodeDomHelper.This(),
-                        GetSimpleTypeClassExpression());
+                    setStatements.Add(
+                        CodeDomHelper.CreateMethodCall(
+                            CodeDomHelper.This(), 
+                            setMethodName,
+                            CodeDomHelper.SetValue(),
+                            new CodePrimitiveExpression(this.propertyName),
+                            CodeDomHelper.This(),
+                            GetSimpleTypeClassExpression())
+                    );
                 }
             }
             else if (validation)
             {
-                setMethodName = string.Concat(setMethodName, "WithValidation");
+                var valueExpr = new CodeSnippetExpression(IsEnum ? "value.ToString()" : "value");
+                CodeMethodInvokeExpression setWithValidation;
                 if (xNameParm)
                 {
                     var setValue = CodeDomHelper.SetValue();
-                    CodeExpression valueExpr = IsEnum ? CodeDomHelper.CreateMethodCall(setValue, "ToString") as CodeExpression : setValue;
-                    methodCall = CodeDomHelper.CreateMethodCall(CodeDomHelper.This(), setMethodName,
+                    setWithValidation = CodeDomHelper.CreateMethodCall(
+                        CodeDomHelper.This(), 
+                        setMethodName + "WithValidation",
                         xNameExpression,
                         valueExpr,
                         new CodePrimitiveExpression(PropertyName),
@@ -914,36 +923,60 @@ namespace Xml.Schema.Linq.CodeGen
                 }
                 else
                 {
-                    methodCall = CodeDomHelper.CreateMethodCall(CodeDomHelper.This(), setMethodName,
-                        CodeDomHelper.SetValue(),
+                    setWithValidation = CodeDomHelper.CreateMethodCall(
+                        CodeDomHelper.This(), 
+                        setMethodName + "WithValidation",
+                        valueExpr,
                         new CodePrimitiveExpression(PropertyName),
                         GetSimpleTypeClassExpression());
+                }
+
+                // Skip validation when the set value is null. Also enum.ToString above would fail.
+                // (Setting an optional element to null actually removes it from DOM.)
+                if (IsNullable)
+                {
+                    setStatements.Add(new CodeConditionStatement(
+                        new CodeSnippetExpression("value == null"),
+                        new[] { new CodeExpressionStatement(CreatePlainSetCall(setMethodName, "null", xNameParm)) },
+                        new[] { new CodeExpressionStatement(setWithValidation) }
+                    ));
+                }
+                else
+                {
+                    setStatements.Add(setWithValidation);
                 }
             }
             else
             {
-                if (xNameParm)
-                {
-                    var setValue = CodeDomHelper.SetValue();
-                    CodeExpression valueExpr = IsEnum ? CodeDomHelper.CreateMethodCall(setValue, "ToString") as CodeExpression : setValue;
-                    methodCall = CodeDomHelper.CreateMethodCall(CodeDomHelper.This(), setMethodName,
-                        xNameExpression,
-                        valueExpr
-                    );
-                    if (!IsRef && typeRef.IsSimpleType)
-                    {
-                        methodCall.Parameters.Add(GetSchemaDatatypeExpression());
-                    }
-                }
-                else
-                {
-                    methodCall = CodeDomHelper.CreateMethodCall(CodeDomHelper.This(), setMethodName,
-                        CodeDomHelper.SetValue(),
-                        GetSchemaDatatypeExpression());
-                }
+                setStatements.Add(CreatePlainSetCall(setMethodName, IsEnum ? "value.ToString()" : "value", xNameParm));
             }
+        }
 
-            return methodCall;
+        private CodeExpression CreatePlainSetCall(string setMethodName, string valueExpr, bool xNameParm)
+        {
+            if (xNameParm)
+            {
+                var methodCall = CodeDomHelper.CreateMethodCall(
+                    CodeDomHelper.This(), 
+                    setMethodName,
+                    xNameExpression,
+                    new CodeSnippetExpression(valueExpr)
+                );
+                if (!IsRef && typeRef.IsSimpleType)
+                {
+                    methodCall.Parameters.Add(GetSchemaDatatypeExpression());
+                }
+                return methodCall;
+            }
+            else
+            {
+                return CodeDomHelper.CreateMethodCall(
+                    CodeDomHelper.This(), 
+                    setMethodName,
+                    new CodeSnippetExpression(valueExpr),
+                    GetSchemaDatatypeExpression()
+                );
+            }
         }
 
         private void AddListGetStatements(CodeStatementCollection getStatements, CodeTypeReference listType,
@@ -1186,7 +1219,7 @@ namespace Xml.Schema.Linq.CodeGen
         private void AddSetStatements(CodeStatementCollection setStatements)
         {
             AddFixedValueChecking(setStatements);
-            setStatements.Add(SetValueMethodCall());
+            AddSetValueMethodCall(setStatements);
         }
 
         private void AddSubstGetStatements(CodeStatementCollection getStatements)


### PR DESCRIPTION
Fixes #22

I first looked if this was better fixed in the core lib or generated code.
The `SetXxxWithValidation` methods don't have enough context to know if `null` is an acceptable value. They only check against the target xsd simple type. Whether null is ok or not depends on the target element/attribute being optional in context.
So I fixed this at the codegen level, which conveniently also works around the `value.ToString()` NRE for enum properties.

## Codegen comparison

Using `wss.xsd` (from the tests) as a baseline, here's the code change for a nullable enum:
```diff
public virtual System.Nullable<EventReceiverType> Type {
            get { /*... */ }
            set {
+                if (value == null) {
+                    this.SetElement(TypeXName, null, XmlSchemaType.GetBuiltInSimpleType(XmlTypeCode.String).Datatype);
+                }
+                else {
                    this.SetElementWithValidation(TypeXName, value.ToString(), "Type", global::Microsoft.Schemas.SharePoint.EventReceiverTypeValidator.TypeDefinition);
+                }
            }
        }
```
It also applies to references, from the same `wss.xsd`:
```diff
        public virtual string SolutionId {
            get { /*...*/ }
            set {
+                if (value == null) {
+                    this.SetElement(SolutionIdXName, null, XmlSchemaType.GetBuiltInSimpleType(XmlTypeCode.String).Datatype);
+                }
+                else {
                    this.SetElementWithValidation(SolutionIdXName, value, "SolutionId", global::Microsoft.Schemas.SharePoint.UniqueIdentifier.TypeDefinition);
+                }
            }
        }
```

## Additional changes
I slipped in two additional changes that may not be obvious:

1. I now call `value.ToString()` when setting an enum on an element plain value (text content). It made the new code easier to write and I just can't see why it wasn't done in this case?
See this comment for additional details:
https://github.com/mamift/LinqToXsdCore/issues/22#issuecomment-778776200

2. On the codepath that doesn't perform validation, I realised that `value.ToString()` can also NRE if value is a nullable enum.
You could say: _"but if value is an enum, there would always be validation, so that can't happen!"._ In theory yes, except I noticed that validation is explicitely disabled for attributes, see this comment for details:
https://github.com/mamift/LinqToXsdCore/issues/22#issuecomment-778769813
I have no idea why it's so and didn't change it.
I transformed the codegen to use `value?.ToString()` though, so that it wouldn't crash with a nullable enum.
**This syntax means users need at least C# 6 to compile the new code, because of the `?.` operator.**
C# 6 is old today, esp. for users targetting .NET Core, so I think that's ok.

Example from `wss.xsd`:
```diff
        public virtual System.Nullable<Microsoft.Schemas.SharePoint.ReferenceType> Type {
            get { /* ... */ }
            set {
-                this.SetAttribute(TypeXName, value.ToString(), XmlSchemaType.GetBuiltInSimpleType(XmlTypeCode.String).Datatype);
+                this.SetAttribute(TypeXName, value?.ToString(), XmlSchemaType.GetBuiltInSimpleType(XmlTypeCode.String).Datatype);
            }
        }
```

## Implementation notes
You'll notice I made a liberal usage of `CodeSnippetExpression`.
This uses code in plain strings and has a few benefits:
- It makes the code easier to read and write as I think `value == null` is much easier on the eyes than the equivalent CodeDom.
- It's more performant as it allocates less and that string is printed verbatim in the output.

It could have a few drawbacks but I don't think they apply here:
- It wouldn't work if we wanted to generate VB sources.
- It is not analyzed by the code that looks for identifiers in scope (to find unique names), but I never declare new identifiers this way.

Also notice that I haven't re-generated the sources in the test project, as I'm not sure what the process is.