### PR TITLE
Re-enabled .NET Core 3.1 as a runtime target for the LinqToXsdCore global CLI tool; also enabled .NET 5 as a runtime target

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -9,7 +9,7 @@
 
   <!-- Package defaults -->
   <PropertyGroup>
-    <Copyright>Copyright (C) 2019-2022 Muhammad Miftah, GitHub Contributors &amp; Microsoft Corporation (2008-2011)</Copyright>
+    <Copyright>Copyright (C) Muhammad Miftah, GitHub Contributors (2019-2022) &amp; Microsoft Corporation (2008-2011)</Copyright>
     <Authors>https://github.com/mamift</Authors>
     <Company>Microsoft Corporation</Company>
     <RepositoryUrl>https://github.com/mamift/LinqToXsdCore</RepositoryUrl>

--- a/LinqToXsd.Schemas/LinqToXsd.Schemas.csproj
+++ b/LinqToXsd.Schemas/LinqToXsd.Schemas.csproj
@@ -17,14 +17,7 @@
   <ItemGroup>
     <Compile Remove="Pubmed\collections.xsd.cs" />
     <Compile Remove="Schemas\Pubmed\collections.xsd.cs" />
-    <Compile Remove="SimpleSchemaElement\SimpleSchema.xsd.cs" />
-    <Compile Remove="SimpleSchema\SimpleSchema.xsd.cs" />
     <Compile Remove="XQueryX\XQueryX.xsd.cs" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <None Include="SimpleSchemaElement\SimpleSchema.xsd.cs" />
-    <None Include="SimpleSchema\SimpleSchema.xsd.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/LinqToXsd/LinqToXsd.csproj
+++ b/LinqToXsd/LinqToXsd.csproj
@@ -1,6 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
+    <TargetFrameworks>net6;net5;netcoreapp3.1</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <Description>A command line tool that facilitates generating code from an XSD; also generates configuration files to control code generation. Do not include this nuget package as a dependency in shipping applications or libraries; use the code it generates in a shipping library or app and include a dependency on the XObjectsCore nuget package. Can be installed via 'dotnet tool install LinqToXsdCore --global', and then invoked via 'linqtoxsd'. Original Authors: Microsoft Corporation.</Description>
   </PropertyGroup>

--- a/LinqToXsd/LinqToXsd.csproj
+++ b/LinqToXsd/LinqToXsd.csproj
@@ -11,6 +11,7 @@
     <ToolCommandName>$(MSBuildProjectName)</ToolCommandName>
     <PackAsTool>true</PackAsTool>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+    <DebugType>embedded</DebugType>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Version.props
+++ b/Version.props
@@ -1,5 +1,5 @@
 <Project>
   <PropertyGroup>
-    <Version>3.3.0</Version>
+    <Version>3.3.1</Version>
   </PropertyGroup>
 </Project>

--- a/XObjectsCode/XObjectsCodeGen.csproj
+++ b/XObjectsCode/XObjectsCodeGen.csproj
@@ -7,6 +7,7 @@
 
   <PropertyGroup>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+    <DebugType>embedded</DebugType>
   </PropertyGroup>
 
   <ItemGroup>

--- a/XObjectsCore/XObjectsCore.csproj
+++ b/XObjectsCore/XObjectsCore.csproj
@@ -7,6 +7,7 @@
 
   <PropertyGroup>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+    <DebugType>embedded</DebugType>
   </PropertyGroup>
 
 </Project>


### PR DESCRIPTION
# Version 3.3.1

* PDB symbols are now embedded in any publicly-shipping assembly in the solution.

* Re-enabled installing LinqToXsd global CLI tool on .NET Core 3.1. Also enabled NET 5 runtime.

* Incremented version number to 3.3.1.