### PR TITLE
Test cases and fixes for DateOnly bugs

### DIFF
--- a/LinqToXsd.Schemas/Tests/DateOnly/DateOnlyTest.xsd
+++ b/LinqToXsd.Schemas/Tests/DateOnly/DateOnlyTest.xsd
@@ -1,19 +1,33 @@
 <?xml version="1.0" encoding="utf-8"?>
-<xs:schema
+<xs:schema 
     targetNamespace="http://linqtoxsd.schemas.org/test/dateonly-test.xsd"
     xmlns="http://linqtoxsd.schemas.org/test/dateonly-test.xsd"
-    xmlns:xs="http://www.w3.org/2001/XMLSchema"
+    xmlns:xs="http://www.w3.org/2001/XMLSchema" 
     elementFormDefault="qualified"
 >
-  <xs:element name="root">
-	<xs:complexType>
-	    <xs:sequence>
-		  <xs:element name="e-datetime" type="xs:dateTime" />
-		  <xs:element name="e-date" type="xs:date" />
-		  <xs:element name="e-time" type="xs:time" />
-	    </xs:sequence>
-      <xs:attribute name="a-date" type="xs:date" />
-	  <xs:attribute name="a-time" type="xs:time" />
-	</xs:complexType>
-  </xs:element>
+    <xs:simpleType name="Post2kDate">
+        <xs:restriction base="xs:date">
+            <xs:minInclusive value="2000-01-01" />
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:simpleType name="HoursTime">
+        <xs:restriction base="xs:time">
+            <xs:pattern value="\d{2}:00:00" />
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:element name="root">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="e-datetime" type="xs:dateTime" />
+                <xs:element name="e-date" type="xs:date" />
+                <xs:element name="e-time" type="xs:time" />
+                <xs:element name="v-date" type="Post2kDate" />
+                <xs:element name="v-time" type="HoursTime" />
+            </xs:sequence>
+            <xs:attribute name="a-date" type="xs:date" />
+            <xs:attribute name="a-time" type="xs:time" />
+        </xs:complexType>
+    </xs:element>
 </xs:schema>

--- a/LinqToXsd.Schemas/Tests/DateOnly/DateOnlyTest.xsd.cs
+++ b/LinqToXsd.Schemas/Tests/DateOnly/DateOnlyTest.xsd.cs
@@ -23,7 +23,7 @@ namespace LinqToXsd.Schemas.Test.DateOnlyTest {
     
     /// <summary>
     /// <para>
-    /// Regular expression: (edatetime, edate, etime)
+    /// Regular expression: (edatetime, edate, etime, vdate, vtime)
     /// </para>
     /// </summary>
     public partial class root : XTypedElement, IXMetaData {
@@ -60,7 +60,7 @@ namespace LinqToXsd.Schemas.Test.DateOnlyTest {
         
         /// <summary>
         /// <para>
-        /// Regular expression: (edatetime, edate, etime)
+        /// Regular expression: (edatetime, edate, etime, vdate, vtime)
         /// </para>
         /// </summary>
         public root() {
@@ -75,7 +75,7 @@ namespace LinqToXsd.Schemas.Test.DateOnlyTest {
         /// Occurrence: required
         /// </para>
         /// <para>
-        /// Regular expression: (edatetime, edate, etime)
+        /// Regular expression: (edatetime, edate, etime, vdate, vtime)
         /// </para>
         /// </summary>
         public virtual System.DateTime edatetime {
@@ -97,7 +97,7 @@ namespace LinqToXsd.Schemas.Test.DateOnlyTest {
         /// Occurrence: required
         /// </para>
         /// <para>
-        /// Regular expression: (edatetime, edate, etime)
+        /// Regular expression: (edatetime, edate, etime, vdate, vtime)
         /// </para>
         /// </summary>
         public virtual System.DateOnly edate {
@@ -119,7 +119,7 @@ namespace LinqToXsd.Schemas.Test.DateOnlyTest {
         /// Occurrence: required
         /// </para>
         /// <para>
-        /// Regular expression: (edatetime, edate, etime)
+        /// Regular expression: (edatetime, edate, etime, vdate, vtime)
         /// </para>
         /// </summary>
         public virtual System.TimeOnly etime {
@@ -129,6 +129,50 @@ namespace LinqToXsd.Schemas.Test.DateOnlyTest {
             }
             set {
                 this.SetElement(etimeXName, value, XmlSchemaType.GetBuiltInSimpleType(XmlTypeCode.Time).Datatype);
+            }
+        }
+        
+        [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        internal static readonly System.Xml.Linq.XName vdateXName = System.Xml.Linq.XName.Get("v-date", "http://linqtoxsd.schemas.org/test/dateonly-test.xsd");
+        
+        /// <summary>
+        /// <para>
+        /// Occurrence: required
+        /// </para>
+        /// <para>
+        /// Regular expression: (edatetime, edate, etime, vdate, vtime)
+        /// </para>
+        /// </summary>
+        public virtual System.DateOnly vdate {
+            get {
+                XElement x = this.GetElement(vdateXName);
+                return XTypedServices.ParseValue<System.DateOnly>(x, XmlSchemaType.GetBuiltInSimpleType(XmlTypeCode.Date).Datatype);
+            }
+            set {
+                this.SetElementWithValidation(vdateXName, value, "vdate", global::LinqToXsd.Schemas.Test.DateOnlyTest.Post2kDate.TypeDefinition);
+            }
+        }
+        
+        [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        internal static readonly System.Xml.Linq.XName vtimeXName = System.Xml.Linq.XName.Get("v-time", "http://linqtoxsd.schemas.org/test/dateonly-test.xsd");
+        
+        /// <summary>
+        /// <para>
+        /// Occurrence: required
+        /// </para>
+        /// <para>
+        /// Regular expression: (edatetime, edate, etime, vdate, vtime)
+        /// </para>
+        /// </summary>
+        public virtual System.TimeOnly vtime {
+            get {
+                XElement x = this.GetElement(vtimeXName);
+                return XTypedServices.ParseValue<System.TimeOnly>(x, XmlSchemaType.GetBuiltInSimpleType(XmlTypeCode.Time).Datatype);
+            }
+            set {
+                this.SetElementWithValidation(vtimeXName, value, "vtime", global::LinqToXsd.Schemas.Test.DateOnlyTest.HoursTime.TypeDefinition);
             }
         }
         
@@ -180,7 +224,7 @@ namespace LinqToXsd.Schemas.Test.DateOnlyTest {
         
         static root() {
             BuildElementDictionary();
-            contentModel = new SequenceContentModelEntity(new NamedContentModelEntity(edatetimeXName), new NamedContentModelEntity(edateXName), new NamedContentModelEntity(etimeXName));
+            contentModel = new SequenceContentModelEntity(new NamedContentModelEntity(edatetimeXName), new NamedContentModelEntity(edateXName), new NamedContentModelEntity(etimeXName), new NamedContentModelEntity(vdateXName), new NamedContentModelEntity(vtimeXName));
         }
         
         [DebuggerBrowsable(DebuggerBrowsableState.Never)]
@@ -190,6 +234,8 @@ namespace LinqToXsd.Schemas.Test.DateOnlyTest {
             localElementDictionary.Add(edatetimeXName, typeof(System.DateTime));
             localElementDictionary.Add(edateXName, typeof(System.DateOnly));
             localElementDictionary.Add(etimeXName, typeof(System.TimeOnly));
+            localElementDictionary.Add(vdateXName, typeof(System.DateOnly));
+            localElementDictionary.Add(vtimeXName, typeof(System.TimeOnly));
         }
         
         [DebuggerBrowsable(DebuggerBrowsableState.Never)]
@@ -226,6 +272,25 @@ namespace LinqToXsd.Schemas.Test.DateOnlyTest {
                 return LinqToXsdTypeManager.Instance;
             }
         }
+    }
+    
+    public sealed class Post2kDate {
+        
+        private Post2kDate() {
+        }
+        
+        [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+        public static Xml.Schema.Linq.SimpleTypeValidator TypeDefinition = new Xml.Schema.Linq.AtomicSimpleTypeValidator(XmlSchemaType.GetBuiltInSimpleType(XmlTypeCode.Date), new Xml.Schema.Linq.RestrictionFacets(((Xml.Schema.Linq.RestrictionFlags)(256)), null, 0, 0, null, null, 0, null, new System.DateTime(630822816000000000), 0, null, 0, XmlSchemaWhiteSpace.Collapse));
+    }
+    
+    public sealed class HoursTime {
+        
+        private HoursTime() {
+        }
+        
+        [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+        public static Xml.Schema.Linq.SimpleTypeValidator TypeDefinition = new Xml.Schema.Linq.AtomicSimpleTypeValidator(XmlSchemaType.GetBuiltInSimpleType(XmlTypeCode.Time), new Xml.Schema.Linq.RestrictionFacets(((Xml.Schema.Linq.RestrictionFlags)(8)), null, 0, 0, null, null, 0, null, null, 0, new string[] {
+                        "\\d{2}:00:00"}, 0, XmlSchemaWhiteSpace.Collapse));
     }
     
     public class LinqToXsdTypeManager : ILinqToXsdTypeManager {

--- a/LinqToXsd.Schemas/Tests/DateTimeOffset/DateTimeOffsetTest.xsd
+++ b/LinqToXsd.Schemas/Tests/DateTimeOffset/DateTimeOffsetTest.xsd
@@ -9,6 +9,9 @@
         <xs:complexType>
             <xs:sequence>
                 <xs:element name="e-datetime" type="xs:dateTime" />
+                <!-- test deserialization of xs:date and xs:time when UseDateOnly = false -->
+                <xs:element name="e-date" type="xs:date" />
+                <xs:element name="e-time" type="xs:time" />
             </xs:sequence>
             <xs:attribute name="a-datetime" type="xs:dateTime" />
         </xs:complexType>

--- a/LinqToXsd.Schemas/Tests/DateTimeOffset/DateTimeOffsetTest.xsd.cs
+++ b/LinqToXsd.Schemas/Tests/DateTimeOffset/DateTimeOffsetTest.xsd.cs
@@ -23,7 +23,7 @@ namespace LinqToXsd.Schemas.Test.DateTimeOffsetTest {
     
     /// <summary>
     /// <para>
-    /// Regular expression: (edatetime)
+    /// Regular expression: (edatetime, edate, etime)
     /// </para>
     /// </summary>
     public partial class root : XTypedElement, IXMetaData {
@@ -60,7 +60,7 @@ namespace LinqToXsd.Schemas.Test.DateTimeOffsetTest {
         
         /// <summary>
         /// <para>
-        /// Regular expression: (edatetime)
+        /// Regular expression: (edatetime, edate, etime)
         /// </para>
         /// </summary>
         public root() {
@@ -75,7 +75,7 @@ namespace LinqToXsd.Schemas.Test.DateTimeOffsetTest {
         /// Occurrence: required
         /// </para>
         /// <para>
-        /// Regular expression: (edatetime)
+        /// Regular expression: (edatetime, edate, etime)
         /// </para>
         /// </summary>
         public virtual System.DateTimeOffset edatetime {
@@ -85,6 +85,50 @@ namespace LinqToXsd.Schemas.Test.DateTimeOffsetTest {
             }
             set {
                 this.SetElement(edatetimeXName, value, XmlSchemaType.GetBuiltInSimpleType(XmlTypeCode.DateTime).Datatype);
+            }
+        }
+        
+        [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        internal static readonly System.Xml.Linq.XName edateXName = System.Xml.Linq.XName.Get("e-date", "http://linqtoxsd.schemas.org/test/datetimeoffset-test.xsd");
+        
+        /// <summary>
+        /// <para>
+        /// Occurrence: required
+        /// </para>
+        /// <para>
+        /// Regular expression: (edatetime, edate, etime)
+        /// </para>
+        /// </summary>
+        public virtual System.DateTime edate {
+            get {
+                XElement x = this.GetElement(edateXName);
+                return XTypedServices.ParseValue<System.DateTime>(x, XmlSchemaType.GetBuiltInSimpleType(XmlTypeCode.Date).Datatype);
+            }
+            set {
+                this.SetElement(edateXName, value, XmlSchemaType.GetBuiltInSimpleType(XmlTypeCode.Date).Datatype);
+            }
+        }
+        
+        [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        internal static readonly System.Xml.Linq.XName etimeXName = System.Xml.Linq.XName.Get("e-time", "http://linqtoxsd.schemas.org/test/datetimeoffset-test.xsd");
+        
+        /// <summary>
+        /// <para>
+        /// Occurrence: required
+        /// </para>
+        /// <para>
+        /// Regular expression: (edatetime, edate, etime)
+        /// </para>
+        /// </summary>
+        public virtual System.DateTime etime {
+            get {
+                XElement x = this.GetElement(etimeXName);
+                return XTypedServices.ParseValue<System.DateTime>(x, XmlSchemaType.GetBuiltInSimpleType(XmlTypeCode.Time).Datatype);
+            }
+            set {
+                this.SetElement(etimeXName, value, XmlSchemaType.GetBuiltInSimpleType(XmlTypeCode.Time).Datatype);
             }
         }
         
@@ -114,7 +158,7 @@ namespace LinqToXsd.Schemas.Test.DateTimeOffsetTest {
         
         static root() {
             BuildElementDictionary();
-            contentModel = new SequenceContentModelEntity(new NamedContentModelEntity(edatetimeXName));
+            contentModel = new SequenceContentModelEntity(new NamedContentModelEntity(edatetimeXName), new NamedContentModelEntity(edateXName), new NamedContentModelEntity(etimeXName));
         }
         
         [DebuggerBrowsable(DebuggerBrowsableState.Never)]
@@ -122,6 +166,8 @@ namespace LinqToXsd.Schemas.Test.DateTimeOffsetTest {
         
         private static void BuildElementDictionary() {
             localElementDictionary.Add(edatetimeXName, typeof(System.DateTimeOffset));
+            localElementDictionary.Add(edateXName, typeof(System.DateTime));
+            localElementDictionary.Add(etimeXName, typeof(System.DateTime));
         }
         
         [DebuggerBrowsable(DebuggerBrowsableState.Never)]

--- a/Version.props
+++ b/Version.props
@@ -1,5 +1,5 @@
 <Project>
   <PropertyGroup>
-    <Version>3.4.3</Version>
+    <Version>3.4.4</Version>
   </PropertyGroup>
 </Project>

--- a/XObjectsCode/XObjectsCodeGen.csproj
+++ b/XObjectsCode/XObjectsCodeGen.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;net6.0</TargetFrameworks>
     <Description>The $(MSBuildProjectName) provides code generation facilities, and is consumed by the LinqToXsdCore command line tool; use the LinqToXsdCore tool to generate code, and link to the XObjectsCore nuget package to consume the generated code in your shipping app or library. Original Authors: Microsoft Corporation.</Description>
-    <Version>3.2.3</Version>
+    <Version>3.2.4</Version>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/XObjectsTests/DatesTests.cs
+++ b/XObjectsTests/DatesTests.cs
@@ -18,6 +18,8 @@ namespace Xml.Schema.Linq.Tests
                 edate = new DateOnly(2023, 12, 25),
                 etime = new TimeOnly(8, 15, 22),
                 edatetime = new DateTime(2023, 06, 30, 14, 39, 00),
+                vdate = new DateOnly(2023, 06, 07), // vdate has restriction > 2000-01-01
+                vtime = new TimeOnly(16, 00, 00), // vtime has pattern \d{2}:00:00
             };
             var writer = new StringWriter();
             doc.Save(writer);
@@ -29,16 +31,20 @@ namespace Xml.Schema.Linq.Tests
             Assert.IsTrue(xml.Contains("<e-date>2023-12-25</e-date>"), "DateOnly element incorrectly serialized");
             Assert.IsTrue(xml.Contains("<e-time>08:15:22</e-time>"), "TimeOnly element incorrectly serialized");
             Assert.IsTrue(xml.Contains("<e-datetime>2023-06-30T14:39:00</e-datetime>"), "DateTime element incorrectly serialized");
+            Assert.IsTrue(xml.Contains("<v-date>2023-06-07</v-date>"), "Validated DateOnly incorrectly serialized");
+            Assert.IsTrue(xml.Contains("<v-time>16:00:00</v-time>"), "Validated TimeOnly incorrectly serialized");
 
             // Parse document
             doc = LinqToXsd.Schemas.Test.DateOnlyTest.root.Parse(xml);
 
             // Verify everything has round-tripped
-            Assert.AreEqual(doc.adate, new DateOnly(2023, 06, 30));
-            Assert.AreEqual(doc.atime, new TimeOnly(14, 39));
-            Assert.AreEqual(doc.edate, new DateOnly(2023, 12, 25));
-            Assert.AreEqual(doc.etime, new TimeOnly(8, 15, 22));
-            Assert.AreEqual(doc.edatetime, new DateTime(2023, 06, 30, 14, 39, 00));
+            Assert.AreEqual(new DateOnly(2023, 06, 30), doc.adate);
+            Assert.AreEqual(new TimeOnly(14, 39), doc.atime);
+            Assert.AreEqual(new DateOnly(2023, 12, 25), doc.edate);
+            Assert.AreEqual(new TimeOnly(8, 15, 22), doc.etime);
+            Assert.AreEqual(new DateTime(2023, 06, 30, 14, 39, 00), doc.edatetime);
+            Assert.AreEqual(new DateOnly(2023, 06, 07), doc.vdate);
+            Assert.AreEqual(new TimeOnly(16, 00, 00), doc.vtime);
         }
 
         [Test]
@@ -47,11 +53,14 @@ namespace Xml.Schema.Linq.Tests
             // Serialize document
 
             var time = new DateTimeOffset(2023, 06, 30, 14, 39, 00, new TimeSpan(12, 45, 00));
+            var dt = new DateTime(2023, 06, 01, 16, 42, 00);
 
             var doc = new LinqToXsd.Schemas.Test.DateTimeOffsetTest.root
             {
                 adatetime = time,
                 edatetime = time,
+                edate = dt,
+                etime = dt,
             };
             var writer = new StringWriter();
             doc.Save(writer);
@@ -60,13 +69,17 @@ namespace Xml.Schema.Linq.Tests
             // Verify DateTimeOffsets types are serialized into the expected format
             Assert.IsTrue(xml.Contains("a-datetime=\"2023-06-30T14:39:00+12:45\""), "DateTimeOffset attribute incorrectly serialized");
             Assert.IsTrue(xml.Contains("<e-datetime>2023-06-30T14:39:00+12:45</e-datetime>"), "DateTimeOffset element incorrectly serialized");
+            Assert.IsTrue(xml.Contains("<e-date>2023-06-01</e-date>"), "DateTime (as date) incorrectly serialized");
+            Assert.IsTrue(xml.Contains("<e-time>16:42:00</e-time>"), "DateTime (as time) incorrectly serialized");
 
             // Parse document
             doc = LinqToXsd.Schemas.Test.DateTimeOffsetTest.root.Parse(xml);
 
             // Verify everything has round-tripped
-            Assert.AreEqual(doc.adatetime, time);
-            Assert.AreEqual(doc.edatetime, time);
+            Assert.AreEqual(time, doc.adatetime);
+            Assert.AreEqual(time, doc.edatetime);
+            Assert.AreEqual(dt.Date, doc.edate);
+            Assert.AreEqual(DateTime.Today.Add(dt.TimeOfDay), doc.etime);
         }
     }
 }


### PR DESCRIPTION
@mamift Apologizes for opening a PR just after today's release.
These are not bugs in today release but a previous one when I added support for DateOnly and TimeOnly, I found them today by coincidence.

I added new test cases to cover the following bugs, and fixed them:
- Simple types that add restrictions to `xs:date` or `xs:time` would not work with `UseDateOnly` or `UseTimeOnly`. 
Cause: there are lots of conversions in validation code, that did not support `DateOnly` or `TimeOnly` values.
(BTW: there are a _lot_ of _redundant_ conversions in the validation/facets code. Opportunity for optimizations at a later time.)
- Regression (`InvalidCastException`) when parsing `xs:date` or `xs:time` into a good old `DateTime`.

~Would appreciate a release on Nuget if you can 🙏~