### PR TITLE
Preserve DateTimeOffset Timezone on validated elements

### DIFF
--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -1,5 +1,11 @@
 # LinqToXsdCore Release Notes
 
+## Version 3.4.6
+Nuget packages:
+* https://www.nuget.org/packages/LinqToXsdCore/3.4.6
+* https://www.nuget.org/packages/XObjectsCore/3.4.6
+  * Fixed a bug where Timezone info was lost (conversions from DateTimeOffset to DateTime no longer occur). 
+
 ## Version 3.4.5
 Nuget packages:
 * https://www.nuget.org/packages/LinqToXsdCore/3.4.5

--- a/Version.props
+++ b/Version.props
@@ -1,5 +1,7 @@
 <Project>
   <PropertyGroup>
-    <Version>3.4.4</Version>
+    <Version>3.4.5</Version>
+    <VersionSuffix>$(VersionSuffix)</VersionSuffix>
+    <Version Condition=" '$(VersionSuffix)' != '' ">$(Version)-$(VersionSuffix)</Version>
   </PropertyGroup>
 </Project>

--- a/Version.props
+++ b/Version.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-    <Version>3.4.5</Version>
+    <Version>3.4.6</Version>
     <VersionSuffix>$(VersionSuffix)</VersionSuffix>
     <Version Condition=" '$(VersionSuffix)' != '' ">$(Version)-$(VersionSuffix)</Version>
   </PropertyGroup>

--- a/Version.props
+++ b/Version.props
@@ -1,5 +1,5 @@
 <Project>
   <PropertyGroup>
-    <Version>3.4.4</Version>
+    <Version>3.4.5</Version>
   </PropertyGroup>
 </Project>

--- a/Version.props
+++ b/Version.props
@@ -1,7 +1,5 @@
 <Project>
   <PropertyGroup>
-    <Version>3.4.5</Version>
-    <VersionSuffix>$(VersionSuffix)</VersionSuffix>
-    <Version Condition=" '$(VersionSuffix)' != '' ">$(Version)-$(VersionSuffix)</Version>
+    <Version>3.4.4</Version>
   </PropertyGroup>
 </Project>

--- a/Version.props
+++ b/Version.props
@@ -1,5 +1,7 @@
 <Project>
   <PropertyGroup>
     <Version>3.4.5</Version>
+    <VersionSuffix>$(VersionSuffix)</VersionSuffix>
+    <Version Condition=" '$(VersionSuffix)' != '' ">$(Version)-$(VersionSuffix)</Version>
   </PropertyGroup>
 </Project>

--- a/XObjectsCode/XObjectsCodeGen.csproj
+++ b/XObjectsCode/XObjectsCodeGen.csproj
@@ -3,7 +3,9 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;net6.0</TargetFrameworks>
     <Description>The $(MSBuildProjectName) provides code generation facilities, and is consumed by the LinqToXsdCore command line tool; use the LinqToXsdCore tool to generate code, and link to the XObjectsCore nuget package to consume the generated code in your shipping app or library. Original Authors: Microsoft Corporation.</Description>
-    <Version>3.2.4</Version>
+    <Version>3.2.6</Version>
+    <VersionSuffix>$(VersionSuffix)</VersionSuffix>
+    <Version Condition=" '$(VersionSuffix)' != '' ">$(Version)-$(VersionSuffix)</Version>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/XObjectsCode/XObjectsCodeGen.csproj
+++ b/XObjectsCode/XObjectsCodeGen.csproj
@@ -4,6 +4,8 @@
     <TargetFrameworks>netstandard2.0;net6.0</TargetFrameworks>
     <Description>The $(MSBuildProjectName) provides code generation facilities, and is consumed by the LinqToXsdCore command line tool; use the LinqToXsdCore tool to generate code, and link to the XObjectsCore nuget package to consume the generated code in your shipping app or library. Original Authors: Microsoft Corporation.</Description>
     <Version>3.2.6</Version>
+    <VersionSuffix>$(VersionSuffix)</VersionSuffix>
+    <Version Condition=" '$(VersionSuffix)' != '' ">$(Version)-$(VersionSuffix)</Version>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/XObjectsCode/XObjectsCodeGen.csproj
+++ b/XObjectsCode/XObjectsCodeGen.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;net6.0</TargetFrameworks>
     <Description>The $(MSBuildProjectName) provides code generation facilities, and is consumed by the LinqToXsdCore command line tool; use the LinqToXsdCore tool to generate code, and link to the XObjectsCore nuget package to consume the generated code in your shipping app or library. Original Authors: Microsoft Corporation.</Description>
-    <Version>3.2.4</Version>
+    <Version>3.2.6</Version>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/XObjectsCode/XObjectsCodeGen.csproj
+++ b/XObjectsCode/XObjectsCodeGen.csproj
@@ -3,9 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;net6.0</TargetFrameworks>
     <Description>The $(MSBuildProjectName) provides code generation facilities, and is consumed by the LinqToXsdCore command line tool; use the LinqToXsdCore tool to generate code, and link to the XObjectsCore nuget package to consume the generated code in your shipping app or library. Original Authors: Microsoft Corporation.</Description>
-    <Version>3.2.6</Version>
-    <VersionSuffix>$(VersionSuffix)</VersionSuffix>
-    <Version Condition=" '$(VersionSuffix)' != '' ">$(Version)-$(VersionSuffix)</Version>
+    <Version>3.2.4</Version>
   </PropertyGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
Using DateTimeOffset support in my project I noticed one more issue:

When the element is a restricted type, then the validating codepath will force-convert the set value to the `XmlTypeCode` type.
The issue here is that `XmlSchemaDatatype` always converts to `DateTime`.
It does not crash (as conversion from `DateTimeOffset` is possible) but we're back in local timezone and the DTO offset is lost, which defeats the purpose of using DTO in the first place :(