### PR TITLE
Attribute with fixed enum value + default/fixed values for elements

### DIFF
--- a/LinqToXsd/Properties/launchSettings.json
+++ b/LinqToXsd/Properties/launchSettings.json
@@ -32,6 +32,24 @@
       "commandLineArgs": "gen \"Microsoft.Search.Query.xsd\" -a",
       "workingDirectory": "..\\GeneratedSchemaLibraries\\Microsoft Search",
       "hotReloadEnabled": false
+    },
+    "AIXM": {
+      "commandName": "Project",
+      "commandLineArgs": "gen \"AIXM_Features.xsd\" -a",
+      "workingDirectory": "..\\GeneratedSchemaLibraries\\AIXM\\aixm-5.1.1",
+      "hotReloadEnabled": false
+    },
+    "Pubmed": {
+      "commandName": "Project",
+      "commandLineArgs": "gen \"efetch-pubmed.xsd\" -a",
+      "workingDirectory": "..\\GeneratedSchemaLibraries\\Pubmed",
+      "hotReloadEnabled": false
+    },
+    "Windows": {
+      "commandName": "Project",
+      "commandLineArgs": "gen \"windowsTaskSched.xsd\" -a",
+      "workingDirectory": "..\\GeneratedSchemaLibraries\\Windows",
+      "hotReloadEnabled": false
     }
   }
 }

--- a/Version.props
+++ b/Version.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-    <Version>3.4.6</Version>
+    <Version>3.4.7</Version>
     <VersionSuffix>$(VersionSuffix)</VersionSuffix>
     <Version Condition=" '$(VersionSuffix)' != '' ">$(Version)-$(VersionSuffix)</Version>
   </PropertyGroup>

--- a/XObjectsCode/Src/ClrBasePropertyInfo.cs
+++ b/XObjectsCode/Src/ClrBasePropertyInfo.cs
@@ -12,7 +12,6 @@ public abstract class ClrBasePropertyInfo : ContentInfo
 
     protected bool hasSet;
     protected XCodeTypeReference returnType;
-    protected XCodeTypeReference defaultValueType;
     protected bool isVirtual;
     protected bool isOverride;
 
@@ -21,10 +20,9 @@ public abstract class ClrBasePropertyInfo : ContentInfo
 
     public ClrBasePropertyInfo()
     {
-        this.IsVirtual = false;
-        this.isOverride = false;
-        this.returnType = null;
-        this.defaultValueType = null;
+        IsVirtual = false;
+        isOverride = false;
+        returnType = null;
         annotations = new List<ClrAnnotation>();
     }
 
@@ -92,12 +90,6 @@ public abstract class ClrBasePropertyInfo : ContentInfo
     {
         get { return returnType; }
         set { returnType = value; }
-    }
-
-    public virtual XCodeTypeReference DefaultValueType
-    {
-        get { return defaultValueType; }
-        set { defaultValueType = value; }
     }
 
     public virtual string ClrTypeName

--- a/XObjectsCode/Src/SimpleTypeCodeDomHelper.cs
+++ b/XObjectsCode/Src/SimpleTypeCodeDomHelper.cs
@@ -409,9 +409,10 @@ namespace Xml.Schema.Linq.CodeGen
         internal static CodeExpression CreateValueExpression(string builtInType, string strValue, bool isEnum)
         {
             int dot = builtInType.LastIndexOf('.');
-            Debug.Assert(dot != -1);
 
-            string localType = builtInType.Substring(dot + 1);
+            string localType = dot < 0 ? builtInType : builtInType.Substring(dot + 1);
+
+            Debug.Assert(dot != -1 || isEnum);  // Enums are local types that may be simple names
 
             if (localType == "String" || localType == "Object")
             {
@@ -445,7 +446,7 @@ namespace Xml.Schema.Linq.CodeGen
         internal static CodeExpression CreateFixedDefaultValueExpression(CodeTypeReference type, string value, bool isEnum)
         {
             string baseType = type.BaseType;
-            if (Regex.IsMatch(baseType, @"\bNullable\b"))
+            if (Regex.IsMatch(baseType, @"\bNullable`1"))
             {
                 Debug.Assert(type.TypeArguments.Count == 1);
                 baseType = type.TypeArguments[0].BaseType;
@@ -461,7 +462,7 @@ namespace Xml.Schema.Linq.CodeGen
                 baseType = type.ArrayElementType.BaseType;
                 return CreateFixedDefaultArrayValueInit(baseType, value, isEnum);
             }
-            else if (Regex.IsMatch(baseType, @"\bList\b"))
+            else if (Regex.IsMatch(baseType, @"\bI?List`1"))
             {
                 //Create sth like: new List<string>(new string[] { });
                 Debug.Assert(type.TypeArguments.Count == 1);

--- a/XObjectsCode/Src/SimpleTypeCodeDomHelper.cs
+++ b/XObjectsCode/Src/SimpleTypeCodeDomHelper.cs
@@ -8,6 +8,7 @@ using System.CodeDom;
 using System.Reflection;
 using System.Diagnostics;
 using System.Globalization;
+using System.Text.RegularExpressions;
 
 namespace Xml.Schema.Linq.CodeGen
 {
@@ -444,10 +445,15 @@ namespace Xml.Schema.Linq.CodeGen
         internal static CodeExpression CreateFixedDefaultValueExpression(CodeTypeReference type, string value, bool isEnum)
         {
             string baseType = type.BaseType;
-            if (baseType.Contains("Nullable"))
+            if (Regex.IsMatch(baseType, @"\bNullable\b"))
             {
                 Debug.Assert(type.TypeArguments.Count == 1);
                 baseType = type.TypeArguments[0].BaseType;
+                return CreateValueExpression(baseType, value, isEnum);
+            }
+            else if (baseType.EndsWith("?"))
+            {
+                baseType = baseType.Substring(0, baseType.Length - 1);
                 return CreateValueExpression(baseType, value, isEnum);
             }
             else if (type.ArrayRank != 0)
@@ -455,7 +461,7 @@ namespace Xml.Schema.Linq.CodeGen
                 baseType = type.ArrayElementType.BaseType;
                 return CreateFixedDefaultArrayValueInit(baseType, value, isEnum);
             }
-            else if (baseType.Contains("List"))
+            else if (Regex.IsMatch(baseType, @"\bList\b"))
             {
                 //Create sth like: new List<string>(new string[] { });
                 Debug.Assert(type.TypeArguments.Count == 1);

--- a/XObjectsCode/Src/SimpleTypeCodeDomHelper.cs
+++ b/XObjectsCode/Src/SimpleTypeCodeDomHelper.cs
@@ -405,7 +405,7 @@ namespace Xml.Schema.Linq.CodeGen
                 new CodePrimitiveExpression(value.ToString()));
         }
 
-        internal static CodeExpression CreateValueExpression(string builtInType, string strValue)
+        internal static CodeExpression CreateValueExpression(string builtInType, string strValue, bool isEnum)
         {
             int dot = builtInType.LastIndexOf('.');
             Debug.Assert(dot != -1);
@@ -415,6 +415,10 @@ namespace Xml.Schema.Linq.CodeGen
             if (localType == "String" || localType == "Object")
             {
                 return new CodePrimitiveExpression(strValue);
+            }
+            else if (isEnum)
+            {
+                return new CodeFieldReferenceExpression(new CodeTypeReferenceExpression(builtInType), strValue);
             }
             else if (localType == "Uri")
             {
@@ -426,30 +430,30 @@ namespace Xml.Schema.Linq.CodeGen
             }
         }
 
-        internal static CodeArrayCreateExpression CreateFixedDefaultArrayValueInit(string baseType, string value)
+        internal static CodeArrayCreateExpression CreateFixedDefaultArrayValueInit(string baseType, string value, bool isEnum)
         {
-            CodeArrayCreateExpression array = new CodeArrayCreateExpression(baseType);
+            var array = new CodeArrayCreateExpression(baseType);
             foreach (string s in value.Split(' '))
             {
-                array.Initializers.Add(CreateValueExpression(baseType, s));
+                array.Initializers.Add(CreateValueExpression(baseType, s, isEnum));
             }
 
             return array;
         }
 
-        internal static CodeExpression CreateFixedDefaultValueExpression(CodeTypeReference type, string value)
+        internal static CodeExpression CreateFixedDefaultValueExpression(CodeTypeReference type, string value, bool isEnum)
         {
             string baseType = type.BaseType;
             if (baseType.Contains("Nullable"))
             {
                 Debug.Assert(type.TypeArguments.Count == 1);
                 baseType = type.TypeArguments[0].BaseType;
-                return CreateValueExpression(baseType, value);
+                return CreateValueExpression(baseType, value, isEnum);
             }
             else if (type.ArrayRank != 0)
             {
                 baseType = type.ArrayElementType.BaseType;
-                return CreateFixedDefaultArrayValueInit(baseType, value);
+                return CreateFixedDefaultArrayValueInit(baseType, value, isEnum);
             }
             else if (baseType.Contains("List"))
             {
@@ -457,10 +461,10 @@ namespace Xml.Schema.Linq.CodeGen
                 Debug.Assert(type.TypeArguments.Count == 1);
 
                 baseType = type.TypeArguments[0].BaseType;
-                return CreateFixedDefaultArrayValueInit(baseType, value);
+                return CreateFixedDefaultArrayValueInit(baseType, value, isEnum);
             }
 
-            return CreateValueExpression(baseType, value);
+            return CreateValueExpression(baseType, value, isEnum);
         }
     }
 }

--- a/XObjectsCode/Src/XsdToTypesConverter.cs
+++ b/XObjectsCode/Src/XsdToTypesConverter.cs
@@ -985,7 +985,7 @@ namespace Xml.Schema.Linq.CodeGen
             propertyInfo.ClrNamespace = clrNs;
             propertyInfo.IsNillable = elem.IsNillable;
 
-            //SetFixedDefaultValue(elem, propertyInfo);
+            SetFixedDefaultValue(elem, propertyInfo);
 
             if (substitutionMembers != null)
             {
@@ -1188,6 +1188,37 @@ namespace Xml.Schema.Linq.CodeGen
                     propertyInfo.unionDefaultType = attribute
                                                     .AttributeSchemaType.Datatype
                                                     .ParseValue(value, new NameTable(), null).GetType();
+                }
+            }
+        }
+
+        private void SetFixedDefaultValue(XmlSchemaElement element, ClrPropertyInfo propertyInfo)
+        {
+            //saves fixed/default value in the corresponding property
+            //Currently only consider fixed/default values for simple types
+            if (element.RefName != null && !element.RefName.IsEmpty)
+            {
+                var globalEl = (XmlSchemaElement)schemas.GlobalElements[element.RefName];
+                propertyInfo.FixedValue = globalEl.FixedValue;
+                propertyInfo.DefaultValue = globalEl.DefaultValue;
+            }
+            else
+            {
+                propertyInfo.FixedValue = element.FixedValue;
+                propertyInfo.DefaultValue = element.DefaultValue;
+            }
+
+            if (element.ElementSchemaType.DerivedBy == XmlSchemaDerivationMethod.Union)
+            {
+                string value = propertyInfo.FixedValue;
+                if (value == null)
+                    value = propertyInfo.DefaultValue;
+                if (value != null)
+                {
+                    propertyInfo.unionDefaultType = element
+                        .ElementSchemaType.Datatype
+                        .ParseValue(value, new NameTable(), null)
+                        .GetType();
                 }
             }
         }

--- a/XObjectsCode/Src/XsdToTypesConverter.cs
+++ b/XObjectsCode/Src/XsdToTypesConverter.cs
@@ -1195,7 +1195,11 @@ namespace Xml.Schema.Linq.CodeGen
         private void SetFixedDefaultValue(XmlSchemaElement element, ClrPropertyInfo propertyInfo)
         {
             //saves fixed/default value in the corresponding property
+
+            if ((element.FixedValue ?? element.DefaultValue) == null) return;
             //Currently only consider fixed/default values for simple types
+            if (element.ElementSchemaType is XmlSchemaComplexType) return;
+
             if (element.RefName != null && !element.RefName.IsEmpty)
             {
                 var globalEl = (XmlSchemaElement)schemas.GlobalElements[element.RefName];

--- a/XObjectsCore/API/XTypedServices.cs
+++ b/XObjectsCore/API/XTypedServices.cs
@@ -399,6 +399,9 @@ namespace Xml.Schema.Linq
             return ParseValue<T>(attribute.Value, attribute.Parent, datatype);
         }
 
+        // Kept for backward compatibility with code generated in previous versions.
+        // Current generator does not use this method anymore, as attributes with default properties
+        // have `if (attr == null) return defaultValue` directly in getter to workaround enum parsing.
         public static T ParseValue<T>(XAttribute attribute, XmlSchemaDatatype datatype, T defaultValue)
         {
             if (attribute == null)


### PR DESCRIPTION
Fixes #68 
... and a bit more because it turned out as a rabbit hole and I got ambitious.

### Background on the bug
There was a `DefaultValueType` that was identical to `ReturnType` except enums were typed as string.
The reason is that enums are not returned by `XTypedService.ParseValue<E>(attr, type, T defaultValue)`.
This would be best, and doable in modern .net, but the legacy generation code had to do 
`(E)Enum.Parse(typeof(E), XTypedService.ParseValue<string>(attr, type, defaultValue))`
and that's why `defaultValue` had to be a string for enums.

That works nicely for default values, but the issue is that the same `DefaultValueType` was used for fixed values and as the linked issue shows, fixed values must be actual enum type and not strings.

### Change 1: Get rid of `DefaultValueType`, fix fixed enums values
I'm simply using `ReturnType` instead. 
The difference is that enum fixed and default values are now declared with their enum type rather than string.

This change fixes #68, here's one example from AIXM schema:
![image](https://github.com/mamift/LinqToXsdCore/assets/3832820/4519a187-9a76-4437-a661-79e63b26522a)

Note that I also reversed the check in setter from `value.Equals(fixed)` to `fixed.Equals(value)`.
I was afraid that if the fixed value is a reference type, such as string, users could pass a `null` value and the check would throw a NRE instead of the more specific error.

### Change 2: fix default values
Of course change 1 broke default enum values because now an enum is passed to `ParseValue<string>` as explained in _Background_.
If fixed it by handling default attribute values differently. Now they're checked in the getter itself with a `if (attr == null) return defaultValue;`. A small benefit is that no more parsing is done for default enums as they're not stored as strings anymore.

Here's an example with an enum (from AIXM):
![image](https://github.com/mamift/LinqToXsdCore/assets/3832820/5ac4d7d6-2e1d-4b28-9c2c-cb2dc9983aac)

And another example with a decimal (from AIXM):
![image](https://github.com/mamift/LinqToXsdCore/assets/3832820/e0291095-403f-4064-a551-503a57242e26)

At this point, overload `ParseValue<T>(XAttribute, type, T defaultValue)` is not needed anymore.
I left a comment but kept the function so that it doesn't break users who upgrade XObjectsCore without regenerating their code.

### Change 3: adding element support
I got ambitious and noted that the code that reads `fixed` and `default` attributes in XSD schema was commented for elements.
I added it, but there is one slight difference worth noting.

Fixed values work the same way. The getter is always returning the fixed value; the setter throws if `value != fixed` and that's it.

The getter for default element values is different though. XSD specs say that default attribute values kick in when attribute is absent, hence my change 2 `if (attr == null) return defaultValue`. But for elements, XSD specs say that the default kicks in for _empty_ elements. Specifically, _missing_ elements are still considered null/absent. So the codegen differs a bit and I scripted `if (elem != null && elem.IsEmpty) return defaultValue`.

Example with an enum but other values work the same (from 1707__ISYBAU_XML_Schema): 
![image](https://github.com/mamift/LinqToXsdCore/assets/3832820/a5337ab2-0ab2-4a69-afd7-a21f94419608)

(Yes that condition is formatted horribly by CodeDOM 😫)