### PR TITLE
[Feature] Support enums with invalid characters.

### DIFF
--- a/GeneratedSchemaLibraries/EnumsTest/EnumsTest.xsd
+++ b/GeneratedSchemaLibraries/EnumsTest/EnumsTest.xsd
@@ -5,12 +5,17 @@
     xmlns:xs="http://www.w3.org/2001/XMLSchema"
     elementFormDefault="qualified"
 >
-
   <xs:element name="Element1" type="GlobalEnumElementType" />
   <xs:element name="Element2" type="GlobalEnumAttributeType" />
   <xs:element name="Element3" type="NestedEnumElementType" />
   <xs:element name="Element4" type="NestedEnumAttributeType" />
   <xs:element name="Element5" type="NestedDerivedEnumAttributeType" />
+
+  <xs:simpleType name="EmptyType">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value=""/>
+    </xs:restriction>
+  </xs:simpleType>
 
   <xs:simpleType name="LanguageCodeEnum">
     <xs:restriction base="xs:NMTOKEN">
@@ -18,10 +23,19 @@
       <xs:enumeration value="fr"/>
     </xs:restriction>
   </xs:simpleType>
+  
+  <xs:simpleType name="InvalidCharEnum">
+    <xs:restriction base="xs:NMTOKEN">
+      <xs:enumeration value="en-fr"/>
+      <xs:enumeration value="fr-de-it"/>
+    </xs:restriction>
+  </xs:simpleType>
 
   <xs:complexType name="GlobalEnumElementType">
     <xs:sequence>
       <xs:element name="Language" type="LanguageCodeEnum" />
+      <xs:element name="Invalid" type="InvalidCharEnum" />
+      <xs:element name="Empty" type="EmptyType" />
     </xs:sequence>
   </xs:complexType>
 
@@ -29,6 +43,7 @@
     <xs:simpleContent>
       <xs:extension base="xs:string">
         <xs:attribute name="language" type="LanguageCodeEnum"/>
+        <xs:attribute name="invalid" type="InvalidCharEnum"/>
       </xs:extension>
     </xs:simpleContent>
   </xs:complexType>
@@ -40,6 +55,14 @@
           <xs:restriction base="xs:NMTOKEN" >
             <xs:enumeration value="en"/>
             <xs:enumeration value="fr"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:element>
+      <xs:element name="Invalid">
+        <xs:simpleType>
+          <xs:restriction base="xs:NMTOKEN" >
+            <xs:enumeration value="en-fr"/>
+            <xs:enumeration value="fr-de-it"/>
           </xs:restriction>
         </xs:simpleType>
       </xs:element>
@@ -55,6 +78,14 @@
         </xs:restriction>
       </xs:simpleType>
     </xs:attribute>
+    <xs:attribute name="invalid">
+      <xs:simpleType>
+        <xs:restriction base="xs:NMTOKEN" >
+          <xs:enumeration value="en-fr"/>
+          <xs:enumeration value="fr-de-it"/>
+        </xs:restriction>
+      </xs:simpleType>
+    </xs:attribute>
   </xs:complexType>
 
   <xs:complexType name="NestedDerivedEnumAttributeType" >
@@ -65,6 +96,15 @@
             <xs:restriction base="xs:NMTOKEN" >
               <xs:enumeration value="de"/>
               <xs:enumeration value="it"/>
+              <xs:enumeration value="rm"/>
+            </xs:restriction>
+          </xs:simpleType>
+        </xs:attribute>
+        <xs:attribute name="additionalInvalid">
+          <xs:simpleType>
+            <xs:restriction base="xs:NMTOKEN" >
+              <xs:enumeration value="de"/>
+              <xs:enumeration value="it-rm"/>
             </xs:restriction>
           </xs:simpleType>
         </xs:attribute>

--- a/GeneratedSchemaLibraries/EnumsTest/EnumsTest.xsd
+++ b/GeneratedSchemaLibraries/EnumsTest/EnumsTest.xsd
@@ -11,6 +11,12 @@
   <xs:element name="Element4" type="NestedEnumAttributeType" />
   <xs:element name="Element5" type="NestedDerivedEnumAttributeType" />
 
+  <xs:simpleType name="VersionType">
+    <xs:restriction base="xs:decimal">
+      <xs:enumeration value="0.0"/>
+    </xs:restriction>
+  </xs:simpleType>
+
   <xs:simpleType name="EmptyType">
     <xs:restriction base="xs:string">
       <xs:enumeration value=""/>
@@ -36,6 +42,7 @@
       <xs:element name="Language" type="LanguageCodeEnum" />
       <xs:element name="Invalid" type="InvalidCharEnum" />
       <xs:element name="Empty" type="EmptyType" />
+      <xs:element name="Version" type="VersionType" />
     </xs:sequence>
   </xs:complexType>
 

--- a/GeneratedSchemaLibraries/EnumsTest/EnumsTest.xsd.cs
+++ b/GeneratedSchemaLibraries/EnumsTest/EnumsTest.xsd.cs
@@ -21,6 +21,16 @@ namespace LinqToXsd.Schemas.Test.EnumsTypes {
     using Xml.Schema.Linq;
     
     
+    public sealed class VersionType {
+        
+        private VersionType() {
+        }
+        
+        [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+        public static Xml.Schema.Linq.SimpleTypeValidator TypeDefinition = new Xml.Schema.Linq.AtomicSimpleTypeValidator(XmlSchemaType.GetBuiltInSimpleType(XmlTypeCode.Decimal), new Xml.Schema.Linq.RestrictionFacets(((Xml.Schema.Linq.RestrictionFlags)(16)), new object[] {
+                        0.0m}, 0, 0, null, null, 0, null, null, 0, null, 0, XmlSchemaWhiteSpace.Collapse));
+    }
+    
     public sealed class EmptyType {
         
         private EmptyType() {
@@ -69,7 +79,7 @@ namespace LinqToXsd.Schemas.Test.EnumsTypes {
     
     /// <summary>
     /// <para>
-    /// Regular expression: (Language, Invalid, Empty)
+    /// Regular expression: (Language, Invalid, Empty, Version)
     /// </para>
     /// </summary>
     public partial class GlobalEnumElementType : XTypedElement, IXMetaData {
@@ -82,7 +92,7 @@ namespace LinqToXsd.Schemas.Test.EnumsTypes {
         
         /// <summary>
         /// <para>
-        /// Regular expression: (Language, Invalid, Empty)
+        /// Regular expression: (Language, Invalid, Empty, Version)
         /// </para>
         /// </summary>
         public GlobalEnumElementType() {
@@ -97,7 +107,7 @@ namespace LinqToXsd.Schemas.Test.EnumsTypes {
         /// Occurrence: required
         /// </para>
         /// <para>
-        /// Regular expression: (Language, Invalid, Empty)
+        /// Regular expression: (Language, Invalid, Empty, Version)
         /// </para>
         /// </summary>
         public virtual LinqToXsd.Schemas.Test.EnumsTypes.LanguageCodeEnum Language {
@@ -119,7 +129,7 @@ namespace LinqToXsd.Schemas.Test.EnumsTypes {
         /// Occurrence: required
         /// </para>
         /// <para>
-        /// Regular expression: (Language, Invalid, Empty)
+        /// Regular expression: (Language, Invalid, Empty, Version)
         /// </para>
         /// </summary>
         public virtual LinqToXsd.Schemas.Test.EnumsTypes.InvalidCharEnum Invalid {
@@ -141,7 +151,7 @@ namespace LinqToXsd.Schemas.Test.EnumsTypes {
         /// Occurrence: required
         /// </para>
         /// <para>
-        /// Regular expression: (Language, Invalid, Empty)
+        /// Regular expression: (Language, Invalid, Empty, Version)
         /// </para>
         /// </summary>
         public virtual string Empty {
@@ -154,11 +164,33 @@ namespace LinqToXsd.Schemas.Test.EnumsTypes {
             }
         }
         
+        [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        protected internal static readonly System.Xml.Linq.XName VersionXName = System.Xml.Linq.XName.Get("Version", "http://linqtoxsd.schemas.org/test/enums-test.xsd");
+        
+        /// <summary>
+        /// <para>
+        /// Occurrence: required
+        /// </para>
+        /// <para>
+        /// Regular expression: (Language, Invalid, Empty, Version)
+        /// </para>
+        /// </summary>
+        public virtual decimal Version {
+            get {
+                XElement x = this.GetElement(VersionXName);
+                return XTypedServices.ParseValue<decimal>(x, XmlSchemaType.GetBuiltInSimpleType(XmlTypeCode.Decimal).Datatype);
+            }
+            set {
+                this.SetElementWithValidation(VersionXName, value, "Version", global::LinqToXsd.Schemas.Test.EnumsTypes.VersionType.TypeDefinition);
+            }
+        }
+        
         private static readonly System.Xml.Linq.XName xName = System.Xml.Linq.XName.Get("GlobalEnumElementType", "http://linqtoxsd.schemas.org/test/enums-test.xsd");
         
         static GlobalEnumElementType() {
             BuildElementDictionary();
-            contentModel = new SequenceContentModelEntity(new NamedContentModelEntity(LanguageXName), new NamedContentModelEntity(InvalidXName), new NamedContentModelEntity(EmptyXName));
+            contentModel = new SequenceContentModelEntity(new NamedContentModelEntity(LanguageXName), new NamedContentModelEntity(InvalidXName), new NamedContentModelEntity(EmptyXName), new NamedContentModelEntity(VersionXName));
         }
         
         [DebuggerBrowsable(DebuggerBrowsableState.Never)]
@@ -168,6 +200,7 @@ namespace LinqToXsd.Schemas.Test.EnumsTypes {
             localElementDictionary.Add(LanguageXName, typeof(string));
             localElementDictionary.Add(InvalidXName, typeof(string));
             localElementDictionary.Add(EmptyXName, typeof(string));
+            localElementDictionary.Add(VersionXName, typeof(decimal));
         }
         
         [DebuggerBrowsable(DebuggerBrowsableState.Never)]
@@ -791,7 +824,7 @@ namespace LinqToXsd.Schemas.Test.EnumsTypes {
         /// Occurrence: required
         /// </para>
         /// <para>
-        /// Regular expression: (Language, Invalid, Empty)
+        /// Regular expression: (Language, Invalid, Empty, Version)
         /// </para>
         /// </summary>
         public virtual LinqToXsd.Schemas.Test.EnumsTypes.LanguageCodeEnum Language {
@@ -808,7 +841,7 @@ namespace LinqToXsd.Schemas.Test.EnumsTypes {
         /// Occurrence: required
         /// </para>
         /// <para>
-        /// Regular expression: (Language, Invalid, Empty)
+        /// Regular expression: (Language, Invalid, Empty, Version)
         /// </para>
         /// </summary>
         public virtual LinqToXsd.Schemas.Test.EnumsTypes.InvalidCharEnum Invalid {
@@ -825,7 +858,7 @@ namespace LinqToXsd.Schemas.Test.EnumsTypes {
         /// Occurrence: required
         /// </para>
         /// <para>
-        /// Regular expression: (Language, Invalid, Empty)
+        /// Regular expression: (Language, Invalid, Empty, Version)
         /// </para>
         /// </summary>
         public virtual string Empty {
@@ -834,6 +867,23 @@ namespace LinqToXsd.Schemas.Test.EnumsTypes {
             }
             set {
                 this.ContentField.Empty = value;
+            }
+        }
+        
+        /// <summary>
+        /// <para>
+        /// Occurrence: required
+        /// </para>
+        /// <para>
+        /// Regular expression: (Language, Invalid, Empty, Version)
+        /// </para>
+        /// </summary>
+        public virtual decimal Version {
+            get {
+                return this.ContentField.Version;
+            }
+            set {
+                this.ContentField.Version = value;
             }
         }
         

--- a/GeneratedSchemaLibraries/EnumsTest/EnumsTest.xsd.cs
+++ b/GeneratedSchemaLibraries/EnumsTest/EnumsTest.xsd.cs
@@ -21,6 +21,16 @@ namespace LinqToXsd.Schemas.Test.EnumsTypes {
     using Xml.Schema.Linq;
     
     
+    public sealed class EmptyType {
+        
+        private EmptyType() {
+        }
+        
+        [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+        public static Xml.Schema.Linq.SimpleTypeValidator TypeDefinition = new Xml.Schema.Linq.AtomicSimpleTypeValidator(XmlSchemaType.GetBuiltInSimpleType(XmlTypeCode.String), new Xml.Schema.Linq.RestrictionFacets(((Xml.Schema.Linq.RestrictionFlags)(16)), new object[] {
+                        ""}, 0, 0, null, null, 0, null, null, 0, null, 0, XmlSchemaWhiteSpace.Preserve));
+    }
+    
     public enum LanguageCodeEnum {
         
         en,
@@ -30,61 +40,70 @@ namespace LinqToXsd.Schemas.Test.EnumsTypes {
     
     public sealed class LanguageCodeEnumValidator {
         
+        private LanguageCodeEnumValidator() {
+        }
+        
         [DebuggerBrowsable(DebuggerBrowsableState.Never)]
         public static Xml.Schema.Linq.SimpleTypeValidator TypeDefinition = new Xml.Schema.Linq.AtomicSimpleTypeValidator(XmlSchemaType.GetBuiltInSimpleType(XmlTypeCode.NmToken), new Xml.Schema.Linq.RestrictionFacets(((Xml.Schema.Linq.RestrictionFlags)(16)), new object[] {
                         "en",
                         "fr"}, 0, 0, null, null, 0, null, null, 0, null, 0, XmlSchemaWhiteSpace.Collapse));
+    }
+    
+    public enum InvalidCharEnum {
         
-        private LanguageCodeEnumValidator() {
+        en_fr,
+        
+        fr_de_it,
+    }
+    
+    public sealed class InvalidCharEnumValidator {
+        
+        private InvalidCharEnumValidator() {
         }
+        
+        [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+        public static Xml.Schema.Linq.SimpleTypeValidator TypeDefinition = new Xml.Schema.Linq.AtomicSimpleTypeValidator(XmlSchemaType.GetBuiltInSimpleType(XmlTypeCode.NmToken), new Xml.Schema.Linq.RestrictionFacets(((Xml.Schema.Linq.RestrictionFlags)(16)), new object[] {
+                        "en-fr:en_fr",
+                        "fr-de-it:fr_de_it"}, 0, 0, null, null, 0, null, null, 0, null, 0, XmlSchemaWhiteSpace.Collapse));
     }
     
     /// <summary>
     /// <para>
-    /// Regular expression: (Language)
+    /// Regular expression: (Language, Invalid, Empty)
     /// </para>
     /// </summary>
     public partial class GlobalEnumElementType : XTypedElement, IXMetaData {
         
-        [DebuggerBrowsable(DebuggerBrowsableState.Never)]
-        [EditorBrowsable(EditorBrowsableState.Never)]
-        internal static readonly System.Xml.Linq.XName LanguageXName = System.Xml.Linq.XName.Get("Language", "http://linqtoxsd.schemas.org/test/enums-test.xsd");
-        
-        private static readonly System.Xml.Linq.XName xName = System.Xml.Linq.XName.Get("GlobalEnumElementType", "http://linqtoxsd.schemas.org/test/enums-test.xsd");
-        
-        [DebuggerBrowsable(DebuggerBrowsableState.Never)]
-        private static Dictionary<System.Xml.Linq.XName, System.Type> localElementDictionary = new Dictionary<System.Xml.Linq.XName, System.Type>();
-        
-        [DebuggerBrowsable(DebuggerBrowsableState.Never)]
-        private static ContentModelEntity contentModel;
-        
 		public static explicit operator GlobalEnumElementType(XElement xe) { return XTypedServices.ToXTypedElement<GlobalEnumElementType>(xe,LinqToXsdTypeManager.Instance as ILinqToXsdTypeManager); }
         
-        static GlobalEnumElementType() {
-            BuildElementDictionary();
-            contentModel = new SequenceContentModelEntity(new NamedContentModelEntity(LanguageXName));
+        public override XTypedElement Clone() {
+            return XTypedServices.CloneXTypedElement<GlobalEnumElementType>(this);
         }
         
         /// <summary>
         /// <para>
-        /// Regular expression: (Language)
+        /// Regular expression: (Language, Invalid, Empty)
         /// </para>
         /// </summary>
         public GlobalEnumElementType() {
         }
+        
+        [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        protected internal static readonly System.Xml.Linq.XName LanguageXName = System.Xml.Linq.XName.Get("Language", "http://linqtoxsd.schemas.org/test/enums-test.xsd");
         
         /// <summary>
         /// <para>
         /// Occurrence: required
         /// </para>
         /// <para>
-        /// Regular expression: (Language)
+        /// Regular expression: (Language, Invalid, Empty)
         /// </para>
         /// </summary>
         public virtual LinqToXsd.Schemas.Test.EnumsTypes.LanguageCodeEnum Language {
             get {
                 XElement x = this.GetElement(LanguageXName);
-                return ((LinqToXsd.Schemas.Test.EnumsTypes.LanguageCodeEnum)(Enum.Parse(typeof(LinqToXsd.Schemas.Test.EnumsTypes.LanguageCodeEnum), XTypedServices.ParseValue<string>(x, XmlSchemaType.GetBuiltInSimpleType(XmlTypeCode.NmToken).Datatype))));
+                return ((LinqToXsd.Schemas.Test.EnumsTypes.LanguageCodeEnum)(Enum.Parse(typeof(LinqToXsd.Schemas.Test.EnumsTypes.LanguageCodeEnum), XTypedServices.ParseValue(x, XmlSchemaType.GetBuiltInSimpleType(XmlTypeCode.NmToken).Datatype, global::LinqToXsd.Schemas.Test.EnumsTypes.LanguageCodeEnumValidator.TypeDefinition))));
             }
             set {
                 this.SetElementWithValidation(LanguageXName, value.ToString(), "Language", global::LinqToXsd.Schemas.Test.EnumsTypes.LanguageCodeEnumValidator.TypeDefinition);
@@ -92,10 +111,77 @@ namespace LinqToXsd.Schemas.Test.EnumsTypes {
         }
         
         [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        protected internal static readonly System.Xml.Linq.XName InvalidXName = System.Xml.Linq.XName.Get("Invalid", "http://linqtoxsd.schemas.org/test/enums-test.xsd");
+        
+        /// <summary>
+        /// <para>
+        /// Occurrence: required
+        /// </para>
+        /// <para>
+        /// Regular expression: (Language, Invalid, Empty)
+        /// </para>
+        /// </summary>
+        public virtual LinqToXsd.Schemas.Test.EnumsTypes.InvalidCharEnum Invalid {
+            get {
+                XElement x = this.GetElement(InvalidXName);
+                return ((LinqToXsd.Schemas.Test.EnumsTypes.InvalidCharEnum)(Enum.Parse(typeof(LinqToXsd.Schemas.Test.EnumsTypes.InvalidCharEnum), XTypedServices.ParseValue(x, XmlSchemaType.GetBuiltInSimpleType(XmlTypeCode.NmToken).Datatype, global::LinqToXsd.Schemas.Test.EnumsTypes.InvalidCharEnumValidator.TypeDefinition))));
+            }
+            set {
+                this.SetElementWithValidation(InvalidXName, value.ToString(), "Invalid", global::LinqToXsd.Schemas.Test.EnumsTypes.InvalidCharEnumValidator.TypeDefinition);
+            }
+        }
+        
+        [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        protected internal static readonly System.Xml.Linq.XName EmptyXName = System.Xml.Linq.XName.Get("Empty", "http://linqtoxsd.schemas.org/test/enums-test.xsd");
+        
+        /// <summary>
+        /// <para>
+        /// Occurrence: required
+        /// </para>
+        /// <para>
+        /// Regular expression: (Language, Invalid, Empty)
+        /// </para>
+        /// </summary>
+        public virtual string Empty {
+            get {
+                XElement x = this.GetElement(EmptyXName);
+                return XTypedServices.ParseValue<string>(x, XmlSchemaType.GetBuiltInSimpleType(XmlTypeCode.String).Datatype);
+            }
+            set {
+                this.SetElementWithValidation(EmptyXName, value, "Empty", global::LinqToXsd.Schemas.Test.EnumsTypes.EmptyType.TypeDefinition);
+            }
+        }
+        
+        private static readonly System.Xml.Linq.XName xName = System.Xml.Linq.XName.Get("GlobalEnumElementType", "http://linqtoxsd.schemas.org/test/enums-test.xsd");
+        
+        static GlobalEnumElementType() {
+            BuildElementDictionary();
+            contentModel = new SequenceContentModelEntity(new NamedContentModelEntity(LanguageXName), new NamedContentModelEntity(InvalidXName), new NamedContentModelEntity(EmptyXName));
+        }
+        
+        [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+        private static Dictionary<System.Xml.Linq.XName, System.Type> localElementDictionary = new Dictionary<System.Xml.Linq.XName, System.Type>();
+        
+        private static void BuildElementDictionary() {
+            localElementDictionary.Add(LanguageXName, typeof(string));
+            localElementDictionary.Add(InvalidXName, typeof(string));
+            localElementDictionary.Add(EmptyXName, typeof(string));
+        }
+        
+        [DebuggerBrowsable(DebuggerBrowsableState.Never)]
         Dictionary<System.Xml.Linq.XName, System.Type> IXMetaData.LocalElementsDictionary {
             get {
                 return localElementDictionary;
             }
+        }
+        
+        [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+        private static ContentModelEntity contentModel;
+        
+        ContentModelEntity IXMetaData.GetContentModel() {
+            return contentModel;
         }
         
         [DebuggerBrowsable(DebuggerBrowsableState.Never)]
@@ -118,36 +204,22 @@ namespace LinqToXsd.Schemas.Test.EnumsTypes {
                 return LinqToXsdTypeManager.Instance;
             }
         }
-        
-        public override XTypedElement Clone() {
-            return XTypedServices.CloneXTypedElement<GlobalEnumElementType>(this);
-        }
-        
-        private static void BuildElementDictionary() {
-            localElementDictionary.Add(LanguageXName, typeof(string));
-        }
-        
-        ContentModelEntity IXMetaData.GetContentModel() {
-            return contentModel;
-        }
     }
     
     public partial class GlobalEnumAttributeType : XTypedElement, IXMetaData {
         
-        [DebuggerBrowsable(DebuggerBrowsableState.Never)]
-        [EditorBrowsable(EditorBrowsableState.Never)]
-        internal static readonly System.Xml.Linq.XName TypedValueXName = System.Xml.Linq.XName.Get("TypedValue", "");
-        
-        [DebuggerBrowsable(DebuggerBrowsableState.Never)]
-        [EditorBrowsable(EditorBrowsableState.Never)]
-        internal static readonly System.Xml.Linq.XName languageXName = System.Xml.Linq.XName.Get("language", "");
-        
-        private static readonly System.Xml.Linq.XName xName = System.Xml.Linq.XName.Get("GlobalEnumAttributeType", "http://linqtoxsd.schemas.org/test/enums-test.xsd");
-        
 		public static explicit operator GlobalEnumAttributeType(XElement xe) { return XTypedServices.ToXTypedElement<GlobalEnumAttributeType>(xe,LinqToXsdTypeManager.Instance as ILinqToXsdTypeManager); }
+        
+        public override XTypedElement Clone() {
+            return XTypedServices.CloneXTypedElement<GlobalEnumAttributeType>(this);
+        }
         
         public GlobalEnumAttributeType() {
         }
+        
+        [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        protected internal static readonly System.Xml.Linq.XName TypedValueXName = System.Xml.Linq.XName.Get("TypedValue", "");
         
         public virtual string TypedValue {
             get {
@@ -158,6 +230,10 @@ namespace LinqToXsd.Schemas.Test.EnumsTypes {
                 this.SetValue(value, XmlSchemaType.GetBuiltInSimpleType(XmlTypeCode.String).Datatype);
             }
         }
+        
+        [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        protected internal static readonly System.Xml.Linq.XName languageXName = System.Xml.Linq.XName.Get("language", "");
         
         /// <summary>
         /// <para>
@@ -170,11 +246,49 @@ namespace LinqToXsd.Schemas.Test.EnumsTypes {
                 if ((x == null)) {
                     return null;
                 }
-                return ((LinqToXsd.Schemas.Test.EnumsTypes.LanguageCodeEnum)(Enum.Parse(typeof(LinqToXsd.Schemas.Test.EnumsTypes.LanguageCodeEnum), XTypedServices.ParseValue<string>(x, XmlSchemaType.GetBuiltInSimpleType(XmlTypeCode.NmToken).Datatype))));
+                return ((LinqToXsd.Schemas.Test.EnumsTypes.LanguageCodeEnum)(Enum.Parse(typeof(LinqToXsd.Schemas.Test.EnumsTypes.LanguageCodeEnum), XTypedServices.ParseValue(x, XmlSchemaType.GetBuiltInSimpleType(XmlTypeCode.NmToken).Datatype, global::LinqToXsd.Schemas.Test.EnumsTypes.LanguageCodeEnumValidator.TypeDefinition))));
             }
             set {
-                this.SetAttribute(languageXName, value?.ToString(), XmlSchemaType.GetBuiltInSimpleType(XmlTypeCode.NmToken).Datatype);
+                if (value == null) {
+                    this.SetAttribute(languageXName, null, XmlSchemaType.GetBuiltInSimpleType(XmlTypeCode.NmToken).Datatype);
+                }
+                else {
+                    this.SetAttributeWithValidation(languageXName, value.ToString(), "language", global::LinqToXsd.Schemas.Test.EnumsTypes.LanguageCodeEnumValidator.TypeDefinition);
+                }
             }
+        }
+        
+        [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        protected internal static readonly System.Xml.Linq.XName invalidXName = System.Xml.Linq.XName.Get("invalid", "");
+        
+        /// <summary>
+        /// <para>
+        /// Occurrence: optional
+        /// </para>
+        /// </summary>
+        public virtual LinqToXsd.Schemas.Test.EnumsTypes.InvalidCharEnum? invalid {
+            get {
+                XAttribute x = this.Attribute(invalidXName);
+                if ((x == null)) {
+                    return null;
+                }
+                return ((LinqToXsd.Schemas.Test.EnumsTypes.InvalidCharEnum)(Enum.Parse(typeof(LinqToXsd.Schemas.Test.EnumsTypes.InvalidCharEnum), XTypedServices.ParseValue(x, XmlSchemaType.GetBuiltInSimpleType(XmlTypeCode.NmToken).Datatype, global::LinqToXsd.Schemas.Test.EnumsTypes.InvalidCharEnumValidator.TypeDefinition))));
+            }
+            set {
+                if (value == null) {
+                    this.SetAttribute(invalidXName, null, XmlSchemaType.GetBuiltInSimpleType(XmlTypeCode.NmToken).Datatype);
+                }
+                else {
+                    this.SetAttributeWithValidation(invalidXName, value.ToString(), "invalid", global::LinqToXsd.Schemas.Test.EnumsTypes.InvalidCharEnumValidator.TypeDefinition);
+                }
+            }
+        }
+        
+        private static readonly System.Xml.Linq.XName xName = System.Xml.Linq.XName.Get("GlobalEnumAttributeType", "http://linqtoxsd.schemas.org/test/enums-test.xsd");
+        
+        ContentModelEntity IXMetaData.GetContentModel() {
+            return ContentModelEntity.Default;
         }
         
         [DebuggerBrowsable(DebuggerBrowsableState.Never)]
@@ -197,66 +311,122 @@ namespace LinqToXsd.Schemas.Test.EnumsTypes {
                 return LinqToXsdTypeManager.Instance;
             }
         }
-        
-        public override XTypedElement Clone() {
-            return XTypedServices.CloneXTypedElement<GlobalEnumAttributeType>(this);
-        }
-        
-        ContentModelEntity IXMetaData.GetContentModel() {
-            return ContentModelEntity.Default;
-        }
     }
     
     /// <summary>
     /// <para>
-    /// Regular expression: (Language)
+    /// Regular expression: (Language, Invalid)
     /// </para>
     /// </summary>
     public partial class NestedEnumElementType : XTypedElement, IXMetaData {
         
-        [DebuggerBrowsable(DebuggerBrowsableState.Never)]
-        [EditorBrowsable(EditorBrowsableState.Never)]
-        internal static readonly System.Xml.Linq.XName LanguageXName = System.Xml.Linq.XName.Get("Language", "http://linqtoxsd.schemas.org/test/enums-test.xsd");
-        
-        private static readonly System.Xml.Linq.XName xName = System.Xml.Linq.XName.Get("NestedEnumElementType", "http://linqtoxsd.schemas.org/test/enums-test.xsd");
-        
-        [DebuggerBrowsable(DebuggerBrowsableState.Never)]
-        private static Dictionary<System.Xml.Linq.XName, System.Type> localElementDictionary = new Dictionary<System.Xml.Linq.XName, System.Type>();
-        
-        [DebuggerBrowsable(DebuggerBrowsableState.Never)]
-        private static ContentModelEntity contentModel;
-        
 		public static explicit operator NestedEnumElementType(XElement xe) { return XTypedServices.ToXTypedElement<NestedEnumElementType>(xe,LinqToXsdTypeManager.Instance as ILinqToXsdTypeManager); }
         
-        static NestedEnumElementType() {
-            BuildElementDictionary();
-            contentModel = new SequenceContentModelEntity(new NamedContentModelEntity(LanguageXName));
+        public override XTypedElement Clone() {
+            return XTypedServices.CloneXTypedElement<NestedEnumElementType>(this);
         }
         
         /// <summary>
         /// <para>
-        /// Regular expression: (Language)
+        /// Regular expression: (Language, Invalid)
         /// </para>
         /// </summary>
         public NestedEnumElementType() {
         }
+        
+        public enum LanguageEnum {
+            
+            en,
+            
+            fr,
+        }
+        
+        public sealed class LanguageEnumValidator {
+            
+            private LanguageEnumValidator() {
+            }
+            
+            [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+            public static Xml.Schema.Linq.SimpleTypeValidator TypeDefinition = new Xml.Schema.Linq.AtomicSimpleTypeValidator(XmlSchemaType.GetBuiltInSimpleType(XmlTypeCode.NmToken), new Xml.Schema.Linq.RestrictionFacets(((Xml.Schema.Linq.RestrictionFlags)(16)), new object[] {
+                            "en",
+                            "fr"}, 0, 0, null, null, 0, null, null, 0, null, 0, XmlSchemaWhiteSpace.Collapse));
+        }
+        
+        [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        protected internal static readonly System.Xml.Linq.XName LanguageXName = System.Xml.Linq.XName.Get("Language", "http://linqtoxsd.schemas.org/test/enums-test.xsd");
         
         /// <summary>
         /// <para>
         /// Occurrence: required
         /// </para>
         /// <para>
-        /// Regular expression: (Language)
+        /// Regular expression: (Language, Invalid)
         /// </para>
         /// </summary>
         public virtual LinqToXsd.Schemas.Test.EnumsTypes.NestedEnumElementType.LanguageEnum Language {
             get {
                 XElement x = this.GetElement(LanguageXName);
-                return ((LinqToXsd.Schemas.Test.EnumsTypes.NestedEnumElementType.LanguageEnum)(Enum.Parse(typeof(LinqToXsd.Schemas.Test.EnumsTypes.NestedEnumElementType.LanguageEnum), XTypedServices.ParseValue<string>(x, XmlSchemaType.GetBuiltInSimpleType(XmlTypeCode.NmToken).Datatype))));
+                return ((LinqToXsd.Schemas.Test.EnumsTypes.NestedEnumElementType.LanguageEnum)(Enum.Parse(typeof(LinqToXsd.Schemas.Test.EnumsTypes.NestedEnumElementType.LanguageEnum), XTypedServices.ParseValue(x, XmlSchemaType.GetBuiltInSimpleType(XmlTypeCode.NmToken).Datatype, LanguageEnumValidator.TypeDefinition))));
             }
             set {
                 this.SetElementWithValidation(LanguageXName, value.ToString(), "Language", LanguageEnumValidator.TypeDefinition);
             }
+        }
+        
+        public enum InvalidEnum {
+            
+            en_fr,
+            
+            fr_de_it,
+        }
+        
+        public sealed class InvalidEnumValidator {
+            
+            private InvalidEnumValidator() {
+            }
+            
+            [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+            public static Xml.Schema.Linq.SimpleTypeValidator TypeDefinition = new Xml.Schema.Linq.AtomicSimpleTypeValidator(XmlSchemaType.GetBuiltInSimpleType(XmlTypeCode.NmToken), new Xml.Schema.Linq.RestrictionFacets(((Xml.Schema.Linq.RestrictionFlags)(16)), new object[] {
+                            "en-fr:en_fr",
+                            "fr-de-it:fr_de_it"}, 0, 0, null, null, 0, null, null, 0, null, 0, XmlSchemaWhiteSpace.Collapse));
+        }
+        
+        [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        protected internal static readonly System.Xml.Linq.XName InvalidXName = System.Xml.Linq.XName.Get("Invalid", "http://linqtoxsd.schemas.org/test/enums-test.xsd");
+        
+        /// <summary>
+        /// <para>
+        /// Occurrence: required
+        /// </para>
+        /// <para>
+        /// Regular expression: (Language, Invalid)
+        /// </para>
+        /// </summary>
+        public virtual LinqToXsd.Schemas.Test.EnumsTypes.NestedEnumElementType.InvalidEnum Invalid {
+            get {
+                XElement x = this.GetElement(InvalidXName);
+                return ((LinqToXsd.Schemas.Test.EnumsTypes.NestedEnumElementType.InvalidEnum)(Enum.Parse(typeof(LinqToXsd.Schemas.Test.EnumsTypes.NestedEnumElementType.InvalidEnum), XTypedServices.ParseValue(x, XmlSchemaType.GetBuiltInSimpleType(XmlTypeCode.NmToken).Datatype, InvalidEnumValidator.TypeDefinition))));
+            }
+            set {
+                this.SetElementWithValidation(InvalidXName, value.ToString(), "Invalid", InvalidEnumValidator.TypeDefinition);
+            }
+        }
+        
+        private static readonly System.Xml.Linq.XName xName = System.Xml.Linq.XName.Get("NestedEnumElementType", "http://linqtoxsd.schemas.org/test/enums-test.xsd");
+        
+        static NestedEnumElementType() {
+            BuildElementDictionary();
+            contentModel = new SequenceContentModelEntity(new NamedContentModelEntity(LanguageXName), new NamedContentModelEntity(InvalidXName));
+        }
+        
+        [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+        private static Dictionary<System.Xml.Linq.XName, System.Type> localElementDictionary = new Dictionary<System.Xml.Linq.XName, System.Type>();
+        
+        private static void BuildElementDictionary() {
+            localElementDictionary.Add(LanguageXName, typeof(string));
+            localElementDictionary.Add(InvalidXName, typeof(string));
         }
         
         [DebuggerBrowsable(DebuggerBrowsableState.Never)]
@@ -267,6 +437,13 @@ namespace LinqToXsd.Schemas.Test.EnumsTypes {
         }
         
         [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+        private static ContentModelEntity contentModel;
+        
+        ContentModelEntity IXMetaData.GetContentModel() {
+            return contentModel;
+        }
+        
+        [DebuggerBrowsable(DebuggerBrowsableState.Never)]
         System.Xml.Linq.XName IXMetaData.SchemaName {
             get {
                 return xName;
@@ -286,17 +463,17 @@ namespace LinqToXsd.Schemas.Test.EnumsTypes {
                 return LinqToXsdTypeManager.Instance;
             }
         }
+    }
+    
+    public partial class NestedEnumAttributeType : XTypedElement, IXMetaData {
+        
+		public static explicit operator NestedEnumAttributeType(XElement xe) { return XTypedServices.ToXTypedElement<NestedEnumAttributeType>(xe,LinqToXsdTypeManager.Instance as ILinqToXsdTypeManager); }
         
         public override XTypedElement Clone() {
-            return XTypedServices.CloneXTypedElement<NestedEnumElementType>(this);
+            return XTypedServices.CloneXTypedElement<NestedEnumAttributeType>(this);
         }
         
-        private static void BuildElementDictionary() {
-            localElementDictionary.Add(LanguageXName, typeof(string));
-        }
-        
-        ContentModelEntity IXMetaData.GetContentModel() {
-            return contentModel;
+        public NestedEnumAttributeType() {
         }
         
         public enum LanguageEnum {
@@ -306,30 +483,20 @@ namespace LinqToXsd.Schemas.Test.EnumsTypes {
             fr,
         }
         
-        private class LanguageEnumValidator {
+        public sealed class LanguageEnumValidator {
+            
+            private LanguageEnumValidator() {
+            }
             
             [DebuggerBrowsable(DebuggerBrowsableState.Never)]
             public static Xml.Schema.Linq.SimpleTypeValidator TypeDefinition = new Xml.Schema.Linq.AtomicSimpleTypeValidator(XmlSchemaType.GetBuiltInSimpleType(XmlTypeCode.NmToken), new Xml.Schema.Linq.RestrictionFacets(((Xml.Schema.Linq.RestrictionFlags)(16)), new object[] {
                             "en",
                             "fr"}, 0, 0, null, null, 0, null, null, 0, null, 0, XmlSchemaWhiteSpace.Collapse));
-            
-            private LanguageEnumValidator() {
-            }
         }
-    }
-    
-    public partial class NestedEnumAttributeType : XTypedElement, IXMetaData {
         
         [DebuggerBrowsable(DebuggerBrowsableState.Never)]
         [EditorBrowsable(EditorBrowsableState.Never)]
-        internal static readonly System.Xml.Linq.XName languageXName = System.Xml.Linq.XName.Get("language", "");
-        
-        private static readonly System.Xml.Linq.XName xName = System.Xml.Linq.XName.Get("NestedEnumAttributeType", "http://linqtoxsd.schemas.org/test/enums-test.xsd");
-        
-		public static explicit operator NestedEnumAttributeType(XElement xe) { return XTypedServices.ToXTypedElement<NestedEnumAttributeType>(xe,LinqToXsdTypeManager.Instance as ILinqToXsdTypeManager); }
-        
-        public NestedEnumAttributeType() {
-        }
+        protected internal static readonly System.Xml.Linq.XName languageXName = System.Xml.Linq.XName.Get("language", "");
         
         /// <summary>
         /// <para>
@@ -342,11 +509,67 @@ namespace LinqToXsd.Schemas.Test.EnumsTypes {
                 if ((x == null)) {
                     return null;
                 }
-                return ((LinqToXsd.Schemas.Test.EnumsTypes.NestedEnumAttributeType.LanguageEnum)(Enum.Parse(typeof(LinqToXsd.Schemas.Test.EnumsTypes.NestedEnumAttributeType.LanguageEnum), XTypedServices.ParseValue<string>(x, XmlSchemaType.GetBuiltInSimpleType(XmlTypeCode.NmToken).Datatype))));
+                return ((LinqToXsd.Schemas.Test.EnumsTypes.NestedEnumAttributeType.LanguageEnum)(Enum.Parse(typeof(LinqToXsd.Schemas.Test.EnumsTypes.NestedEnumAttributeType.LanguageEnum), XTypedServices.ParseValue(x, XmlSchemaType.GetBuiltInSimpleType(XmlTypeCode.NmToken).Datatype, LanguageEnumValidator.TypeDefinition))));
             }
             set {
-                this.SetAttribute(languageXName, value?.ToString(), XmlSchemaType.GetBuiltInSimpleType(XmlTypeCode.NmToken).Datatype);
+                if (value == null) {
+                    this.SetAttribute(languageXName, null, XmlSchemaType.GetBuiltInSimpleType(XmlTypeCode.NmToken).Datatype);
+                }
+                else {
+                    this.SetAttributeWithValidation(languageXName, value.ToString(), "language", LanguageEnumValidator.TypeDefinition);
+                }
             }
+        }
+        
+        public enum InvalidEnum {
+            
+            en_fr,
+            
+            fr_de_it,
+        }
+        
+        public sealed class InvalidEnumValidator {
+            
+            private InvalidEnumValidator() {
+            }
+            
+            [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+            public static Xml.Schema.Linq.SimpleTypeValidator TypeDefinition = new Xml.Schema.Linq.AtomicSimpleTypeValidator(XmlSchemaType.GetBuiltInSimpleType(XmlTypeCode.NmToken), new Xml.Schema.Linq.RestrictionFacets(((Xml.Schema.Linq.RestrictionFlags)(16)), new object[] {
+                            "en-fr:en_fr",
+                            "fr-de-it:fr_de_it"}, 0, 0, null, null, 0, null, null, 0, null, 0, XmlSchemaWhiteSpace.Collapse));
+        }
+        
+        [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        protected internal static readonly System.Xml.Linq.XName invalidXName = System.Xml.Linq.XName.Get("invalid", "");
+        
+        /// <summary>
+        /// <para>
+        /// Occurrence: optional
+        /// </para>
+        /// </summary>
+        public virtual LinqToXsd.Schemas.Test.EnumsTypes.NestedEnumAttributeType.InvalidEnum? invalid {
+            get {
+                XAttribute x = this.Attribute(invalidXName);
+                if ((x == null)) {
+                    return null;
+                }
+                return ((LinqToXsd.Schemas.Test.EnumsTypes.NestedEnumAttributeType.InvalidEnum)(Enum.Parse(typeof(LinqToXsd.Schemas.Test.EnumsTypes.NestedEnumAttributeType.InvalidEnum), XTypedServices.ParseValue(x, XmlSchemaType.GetBuiltInSimpleType(XmlTypeCode.NmToken).Datatype, InvalidEnumValidator.TypeDefinition))));
+            }
+            set {
+                if (value == null) {
+                    this.SetAttribute(invalidXName, null, XmlSchemaType.GetBuiltInSimpleType(XmlTypeCode.NmToken).Datatype);
+                }
+                else {
+                    this.SetAttributeWithValidation(invalidXName, value.ToString(), "invalid", InvalidEnumValidator.TypeDefinition);
+                }
+            }
+        }
+        
+        private static readonly System.Xml.Linq.XName xName = System.Xml.Linq.XName.Get("NestedEnumAttributeType", "http://linqtoxsd.schemas.org/test/enums-test.xsd");
+        
+        ContentModelEntity IXMetaData.GetContentModel() {
+            return ContentModelEntity.Default;
         }
         
         [DebuggerBrowsable(DebuggerBrowsableState.Never)]
@@ -369,35 +592,43 @@ namespace LinqToXsd.Schemas.Test.EnumsTypes {
                 return LinqToXsdTypeManager.Instance;
             }
         }
-        
-        public override XTypedElement Clone() {
-            return XTypedServices.CloneXTypedElement<NestedEnumAttributeType>(this);
-        }
-        
-        ContentModelEntity IXMetaData.GetContentModel() {
-            return ContentModelEntity.Default;
-        }
-        
-        public enum LanguageEnum {
-            
-            en,
-            
-            fr,
-        }
     }
     
     public partial class NestedDerivedEnumAttributeType : global::LinqToXsd.Schemas.Test.EnumsTypes.NestedEnumAttributeType, IXMetaData {
         
-        [DebuggerBrowsable(DebuggerBrowsableState.Never)]
-        [EditorBrowsable(EditorBrowsableState.Never)]
-        internal static readonly System.Xml.Linq.XName additionalLanguageXName = System.Xml.Linq.XName.Get("additionalLanguage", "");
-        
-        private static readonly System.Xml.Linq.XName xName = System.Xml.Linq.XName.Get("NestedDerivedEnumAttributeType", "http://linqtoxsd.schemas.org/test/enums-test.xsd");
-        
 		public static explicit operator NestedDerivedEnumAttributeType(XElement xe) { return XTypedServices.ToXTypedElement<NestedDerivedEnumAttributeType>(xe,LinqToXsdTypeManager.Instance as ILinqToXsdTypeManager); }
+        
+        public override XTypedElement Clone() {
+            return XTypedServices.CloneXTypedElement<NestedDerivedEnumAttributeType>(this);
+        }
         
         public NestedDerivedEnumAttributeType() {
         }
+        
+        public enum AdditionalLanguageEnum {
+            
+            de,
+            
+            it,
+            
+            rm,
+        }
+        
+        public sealed class AdditionalLanguageEnumValidator {
+            
+            private AdditionalLanguageEnumValidator() {
+            }
+            
+            [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+            public static Xml.Schema.Linq.SimpleTypeValidator TypeDefinition = new Xml.Schema.Linq.AtomicSimpleTypeValidator(XmlSchemaType.GetBuiltInSimpleType(XmlTypeCode.NmToken), new Xml.Schema.Linq.RestrictionFacets(((Xml.Schema.Linq.RestrictionFlags)(16)), new object[] {
+                            "de",
+                            "it",
+                            "rm"}, 0, 0, null, null, 0, null, null, 0, null, 0, XmlSchemaWhiteSpace.Collapse));
+        }
+        
+        [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        protected internal static readonly System.Xml.Linq.XName additionalLanguageXName = System.Xml.Linq.XName.Get("additionalLanguage", "");
         
         /// <summary>
         /// <para>
@@ -410,12 +641,64 @@ namespace LinqToXsd.Schemas.Test.EnumsTypes {
                 if ((x == null)) {
                     return null;
                 }
-                return ((LinqToXsd.Schemas.Test.EnumsTypes.NestedDerivedEnumAttributeType.AdditionalLanguageEnum)(Enum.Parse(typeof(LinqToXsd.Schemas.Test.EnumsTypes.NestedDerivedEnumAttributeType.AdditionalLanguageEnum), XTypedServices.ParseValue<string>(x, XmlSchemaType.GetBuiltInSimpleType(XmlTypeCode.NmToken).Datatype))));
+                return ((LinqToXsd.Schemas.Test.EnumsTypes.NestedDerivedEnumAttributeType.AdditionalLanguageEnum)(Enum.Parse(typeof(LinqToXsd.Schemas.Test.EnumsTypes.NestedDerivedEnumAttributeType.AdditionalLanguageEnum), XTypedServices.ParseValue(x, XmlSchemaType.GetBuiltInSimpleType(XmlTypeCode.NmToken).Datatype, AdditionalLanguageEnumValidator.TypeDefinition))));
             }
             set {
-                this.SetAttribute(additionalLanguageXName, value?.ToString(), XmlSchemaType.GetBuiltInSimpleType(XmlTypeCode.NmToken).Datatype);
+                if (value == null) {
+                    this.SetAttribute(additionalLanguageXName, null, XmlSchemaType.GetBuiltInSimpleType(XmlTypeCode.NmToken).Datatype);
+                }
+                else {
+                    this.SetAttributeWithValidation(additionalLanguageXName, value.ToString(), "additionalLanguage", AdditionalLanguageEnumValidator.TypeDefinition);
+                }
             }
         }
+        
+        public enum AdditionalInvalidEnum {
+            
+            de,
+            
+            it_rm,
+        }
+        
+        public sealed class AdditionalInvalidEnumValidator {
+            
+            private AdditionalInvalidEnumValidator() {
+            }
+            
+            [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+            public static Xml.Schema.Linq.SimpleTypeValidator TypeDefinition = new Xml.Schema.Linq.AtomicSimpleTypeValidator(XmlSchemaType.GetBuiltInSimpleType(XmlTypeCode.NmToken), new Xml.Schema.Linq.RestrictionFacets(((Xml.Schema.Linq.RestrictionFlags)(16)), new object[] {
+                            "de",
+                            "it-rm:it_rm"}, 0, 0, null, null, 0, null, null, 0, null, 0, XmlSchemaWhiteSpace.Collapse));
+        }
+        
+        [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        protected internal static readonly System.Xml.Linq.XName additionalInvalidXName = System.Xml.Linq.XName.Get("additionalInvalid", "");
+        
+        /// <summary>
+        /// <para>
+        /// Occurrence: optional
+        /// </para>
+        /// </summary>
+        public virtual LinqToXsd.Schemas.Test.EnumsTypes.NestedDerivedEnumAttributeType.AdditionalInvalidEnum? additionalInvalid {
+            get {
+                XAttribute x = this.Attribute(additionalInvalidXName);
+                if ((x == null)) {
+                    return null;
+                }
+                return ((LinqToXsd.Schemas.Test.EnumsTypes.NestedDerivedEnumAttributeType.AdditionalInvalidEnum)(Enum.Parse(typeof(LinqToXsd.Schemas.Test.EnumsTypes.NestedDerivedEnumAttributeType.AdditionalInvalidEnum), XTypedServices.ParseValue(x, XmlSchemaType.GetBuiltInSimpleType(XmlTypeCode.NmToken).Datatype, AdditionalInvalidEnumValidator.TypeDefinition))));
+            }
+            set {
+                if (value == null) {
+                    this.SetAttribute(additionalInvalidXName, null, XmlSchemaType.GetBuiltInSimpleType(XmlTypeCode.NmToken).Datatype);
+                }
+                else {
+                    this.SetAttributeWithValidation(additionalInvalidXName, value.ToString(), "additionalInvalid", AdditionalInvalidEnumValidator.TypeDefinition);
+                }
+            }
+        }
+        
+        private static readonly System.Xml.Linq.XName xName = System.Xml.Linq.XName.Get("NestedDerivedEnumAttributeType", "http://linqtoxsd.schemas.org/test/enums-test.xsd");
         
         [DebuggerBrowsable(DebuggerBrowsableState.Never)]
         System.Xml.Linq.XName IXMetaData.SchemaName {
@@ -437,102 +720,9 @@ namespace LinqToXsd.Schemas.Test.EnumsTypes {
                 return LinqToXsdTypeManager.Instance;
             }
         }
-        
-        public override XTypedElement Clone() {
-            return XTypedServices.CloneXTypedElement<NestedDerivedEnumAttributeType>(this);
-        }
-        
-        public enum AdditionalLanguageEnum {
-            
-            de,
-            
-            it,
-        }
     }
     
     public partial class Element1 : XTypedElement, IXMetaData {
-        
-        [DebuggerBrowsable(DebuggerBrowsableState.Never)]
-        private GlobalEnumElementType ContentField;
-        
-        private static readonly System.Xml.Linq.XName xName = System.Xml.Linq.XName.Get("Element1", "http://linqtoxsd.schemas.org/test/enums-test.xsd");
-        
-		public static explicit operator Element1(XElement xe) { return XTypedServices.ToXTypedElement<Element1, GlobalEnumElementType>(xe,LinqToXsdTypeManager.Instance as ILinqToXsdTypeManager); }
-        
-        public Element1() {
-            SetInnerType(new GlobalEnumElementType());
-        }
-        
-        public Element1(GlobalEnumElementType content) {
-            SetInnerType(content);
-        }
-        
-        public override XElement Untyped {
-            get {
-                return base.Untyped;
-            }
-            set {
-                base.Untyped = value;
-                this.ContentField.Untyped = value;
-            }
-        }
-        
-        public virtual GlobalEnumElementType Content {
-            get {
-                return ContentField;
-            }
-        }
-        
-        /// <summary>
-        /// <para>
-        /// Occurrence: required
-        /// </para>
-        /// <para>
-        /// Regular expression: (Language)
-        /// </para>
-        /// </summary>
-        public virtual LinqToXsd.Schemas.Test.EnumsTypes.LanguageCodeEnum Language {
-            get {
-                return this.ContentField.Language;
-            }
-            set {
-                this.ContentField.Language = value;
-            }
-        }
-        
-        Dictionary<System.Xml.Linq.XName, System.Type> IXMetaData.LocalElementsDictionary {
-            get {
-                IXMetaData schemaMetaData = ((IXMetaData)(this.Content));
-                return schemaMetaData.LocalElementsDictionary;
-            }
-        }
-        
-        XTypedElement IXMetaData.Content {
-            get {
-                return this.Content;
-            }
-        }
-        
-        [DebuggerBrowsable(DebuggerBrowsableState.Never)]
-        System.Xml.Linq.XName IXMetaData.SchemaName {
-            get {
-                return xName;
-            }
-        }
-        
-        [DebuggerBrowsable(DebuggerBrowsableState.Never)]
-        SchemaOrigin IXMetaData.TypeOrigin {
-            get {
-                return SchemaOrigin.Element;
-            }
-        }
-        
-        [DebuggerBrowsable(DebuggerBrowsableState.Never)]
-        ILinqToXsdTypeManager IXMetaData.TypeManager {
-            get {
-                return LinqToXsdTypeManager.Instance;
-            }
-        }
         
         public void Save(string xmlFile) {
             XTypedServices.Save(xmlFile, Untyped);
@@ -558,35 +748,17 @@ namespace LinqToXsd.Schemas.Test.EnumsTypes {
             return XTypedServices.Parse<Element1, GlobalEnumElementType>(xml, LinqToXsdTypeManager.Instance);
         }
         
+		public static explicit operator Element1(XElement xe) { return XTypedServices.ToXTypedElement<Element1, GlobalEnumElementType>(xe,LinqToXsdTypeManager.Instance as ILinqToXsdTypeManager); }
+        
         public override XTypedElement Clone() {
             return new Element1(((GlobalEnumElementType)(this.Content.Clone())));
         }
         
-        private void SetInnerType(GlobalEnumElementType ContentField) {
-            this.ContentField = ((GlobalEnumElementType)(XTypedServices.GetCloneIfRooted(ContentField)));
-            XTypedServices.SetName(this, this.ContentField);
-        }
-        
-        ContentModelEntity IXMetaData.GetContentModel() {
-            return ContentModelEntity.Default;
-        }
-    }
-    
-    public partial class Element2 : XTypedElement, IXMetaData {
-        
         [DebuggerBrowsable(DebuggerBrowsableState.Never)]
-        private GlobalEnumAttributeType ContentField;
+        private GlobalEnumElementType ContentField;
         
-        private static readonly System.Xml.Linq.XName xName = System.Xml.Linq.XName.Get("Element2", "http://linqtoxsd.schemas.org/test/enums-test.xsd");
-        
-		public static explicit operator Element2(XElement xe) { return XTypedServices.ToXTypedElement<Element2, GlobalEnumAttributeType>(xe,LinqToXsdTypeManager.Instance as ILinqToXsdTypeManager); }
-        
-        public Element2() {
-            SetInnerType(new GlobalEnumAttributeType());
-        }
-        
-        public Element2(GlobalEnumAttributeType content) {
-            SetInnerType(content);
+        public Element1() {
+            SetInnerType(new GlobalEnumElementType());
         }
         
         public override XElement Untyped {
@@ -599,34 +771,73 @@ namespace LinqToXsd.Schemas.Test.EnumsTypes {
             }
         }
         
-        public virtual GlobalEnumAttributeType Content {
+        public virtual GlobalEnumElementType Content {
             get {
                 return ContentField;
             }
         }
         
-        public virtual string TypedValue {
+        private void SetInnerType(GlobalEnumElementType ContentField) {
+            this.ContentField = ((GlobalEnumElementType)(XTypedServices.GetCloneIfRooted(ContentField)));
+            XTypedServices.SetName(this, this.ContentField);
+        }
+        
+        public Element1(GlobalEnumElementType content) {
+            SetInnerType(content);
+        }
+        
+        /// <summary>
+        /// <para>
+        /// Occurrence: required
+        /// </para>
+        /// <para>
+        /// Regular expression: (Language, Invalid, Empty)
+        /// </para>
+        /// </summary>
+        public virtual LinqToXsd.Schemas.Test.EnumsTypes.LanguageCodeEnum Language {
             get {
-                return this.ContentField.TypedValue;
+                return this.ContentField.Language;
             }
             set {
-                this.ContentField.TypedValue = value;
+                this.ContentField.Language = value;
             }
         }
         
         /// <summary>
         /// <para>
-        /// Occurrence: optional
+        /// Occurrence: required
+        /// </para>
+        /// <para>
+        /// Regular expression: (Language, Invalid, Empty)
         /// </para>
         /// </summary>
-        public virtual LinqToXsd.Schemas.Test.EnumsTypes.LanguageCodeEnum? language {
+        public virtual LinqToXsd.Schemas.Test.EnumsTypes.InvalidCharEnum Invalid {
             get {
-                return this.ContentField.language;
+                return this.ContentField.Invalid;
             }
             set {
-                this.ContentField.language = value;
+                this.ContentField.Invalid = value;
             }
         }
+        
+        /// <summary>
+        /// <para>
+        /// Occurrence: required
+        /// </para>
+        /// <para>
+        /// Regular expression: (Language, Invalid, Empty)
+        /// </para>
+        /// </summary>
+        public virtual string Empty {
+            get {
+                return this.ContentField.Empty;
+            }
+            set {
+                this.ContentField.Empty = value;
+            }
+        }
+        
+        private static readonly System.Xml.Linq.XName xName = System.Xml.Linq.XName.Get("Element1", "http://linqtoxsd.schemas.org/test/enums-test.xsd");
         
         Dictionary<System.Xml.Linq.XName, System.Type> IXMetaData.LocalElementsDictionary {
             get {
@@ -639,6 +850,10 @@ namespace LinqToXsd.Schemas.Test.EnumsTypes {
             get {
                 return this.Content;
             }
+        }
+        
+        ContentModelEntity IXMetaData.GetContentModel() {
+            return ContentModelEntity.Default;
         }
         
         [DebuggerBrowsable(DebuggerBrowsableState.Never)]
@@ -661,6 +876,9 @@ namespace LinqToXsd.Schemas.Test.EnumsTypes {
                 return LinqToXsdTypeManager.Instance;
             }
         }
+    }
+    
+    public partial class Element2 : XTypedElement, IXMetaData {
         
         public void Save(string xmlFile) {
             XTypedServices.Save(xmlFile, Untyped);
@@ -686,35 +904,17 @@ namespace LinqToXsd.Schemas.Test.EnumsTypes {
             return XTypedServices.Parse<Element2, GlobalEnumAttributeType>(xml, LinqToXsdTypeManager.Instance);
         }
         
+		public static explicit operator Element2(XElement xe) { return XTypedServices.ToXTypedElement<Element2, GlobalEnumAttributeType>(xe,LinqToXsdTypeManager.Instance as ILinqToXsdTypeManager); }
+        
         public override XTypedElement Clone() {
             return new Element2(((GlobalEnumAttributeType)(this.Content.Clone())));
         }
         
-        private void SetInnerType(GlobalEnumAttributeType ContentField) {
-            this.ContentField = ((GlobalEnumAttributeType)(XTypedServices.GetCloneIfRooted(ContentField)));
-            XTypedServices.SetName(this, this.ContentField);
-        }
-        
-        ContentModelEntity IXMetaData.GetContentModel() {
-            return ContentModelEntity.Default;
-        }
-    }
-    
-    public partial class Element3 : XTypedElement, IXMetaData {
-        
         [DebuggerBrowsable(DebuggerBrowsableState.Never)]
-        private NestedEnumElementType ContentField;
+        private GlobalEnumAttributeType ContentField;
         
-        private static readonly System.Xml.Linq.XName xName = System.Xml.Linq.XName.Get("Element3", "http://linqtoxsd.schemas.org/test/enums-test.xsd");
-        
-		public static explicit operator Element3(XElement xe) { return XTypedServices.ToXTypedElement<Element3, NestedEnumElementType>(xe,LinqToXsdTypeManager.Instance as ILinqToXsdTypeManager); }
-        
-        public Element3() {
-            SetInnerType(new NestedEnumElementType());
-        }
-        
-        public Element3(NestedEnumElementType content) {
-            SetInnerType(content);
+        public Element2() {
+            SetInnerType(new GlobalEnumAttributeType());
         }
         
         public override XElement Untyped {
@@ -727,28 +927,59 @@ namespace LinqToXsd.Schemas.Test.EnumsTypes {
             }
         }
         
-        public virtual NestedEnumElementType Content {
+        public virtual GlobalEnumAttributeType Content {
             get {
                 return ContentField;
             }
         }
         
-        /// <summary>
-        /// <para>
-        /// Occurrence: required
-        /// </para>
-        /// <para>
-        /// Regular expression: (Language)
-        /// </para>
-        /// </summary>
-        public virtual LinqToXsd.Schemas.Test.EnumsTypes.NestedEnumElementType.LanguageEnum Language {
+        private void SetInnerType(GlobalEnumAttributeType ContentField) {
+            this.ContentField = ((GlobalEnumAttributeType)(XTypedServices.GetCloneIfRooted(ContentField)));
+            XTypedServices.SetName(this, this.ContentField);
+        }
+        
+        public Element2(GlobalEnumAttributeType content) {
+            SetInnerType(content);
+        }
+        
+        public virtual string TypedValue {
             get {
-                return this.ContentField.Language;
+                return this.ContentField.TypedValue;
             }
             set {
-                this.ContentField.Language = value;
+                this.ContentField.TypedValue = value;
             }
         }
+        
+        /// <summary>
+        /// <para>
+        /// Occurrence: optional
+        /// </para>
+        /// </summary>
+        public virtual LinqToXsd.Schemas.Test.EnumsTypes.LanguageCodeEnum? language {
+            get {
+                return this.ContentField.language;
+            }
+            set {
+                this.ContentField.language = value;
+            }
+        }
+        
+        /// <summary>
+        /// <para>
+        /// Occurrence: optional
+        /// </para>
+        /// </summary>
+        public virtual LinqToXsd.Schemas.Test.EnumsTypes.InvalidCharEnum? invalid {
+            get {
+                return this.ContentField.invalid;
+            }
+            set {
+                this.ContentField.invalid = value;
+            }
+        }
+        
+        private static readonly System.Xml.Linq.XName xName = System.Xml.Linq.XName.Get("Element2", "http://linqtoxsd.schemas.org/test/enums-test.xsd");
         
         Dictionary<System.Xml.Linq.XName, System.Type> IXMetaData.LocalElementsDictionary {
             get {
@@ -761,6 +992,10 @@ namespace LinqToXsd.Schemas.Test.EnumsTypes {
             get {
                 return this.Content;
             }
+        }
+        
+        ContentModelEntity IXMetaData.GetContentModel() {
+            return ContentModelEntity.Default;
         }
         
         [DebuggerBrowsable(DebuggerBrowsableState.Never)]
@@ -783,6 +1018,9 @@ namespace LinqToXsd.Schemas.Test.EnumsTypes {
                 return LinqToXsdTypeManager.Instance;
             }
         }
+    }
+    
+    public partial class Element3 : XTypedElement, IXMetaData {
         
         public void Save(string xmlFile) {
             XTypedServices.Save(xmlFile, Untyped);
@@ -808,35 +1046,17 @@ namespace LinqToXsd.Schemas.Test.EnumsTypes {
             return XTypedServices.Parse<Element3, NestedEnumElementType>(xml, LinqToXsdTypeManager.Instance);
         }
         
+		public static explicit operator Element3(XElement xe) { return XTypedServices.ToXTypedElement<Element3, NestedEnumElementType>(xe,LinqToXsdTypeManager.Instance as ILinqToXsdTypeManager); }
+        
         public override XTypedElement Clone() {
             return new Element3(((NestedEnumElementType)(this.Content.Clone())));
         }
         
-        private void SetInnerType(NestedEnumElementType ContentField) {
-            this.ContentField = ((NestedEnumElementType)(XTypedServices.GetCloneIfRooted(ContentField)));
-            XTypedServices.SetName(this, this.ContentField);
-        }
-        
-        ContentModelEntity IXMetaData.GetContentModel() {
-            return ContentModelEntity.Default;
-        }
-    }
-    
-    public partial class Element4 : XTypedElement, IXMetaData {
-        
         [DebuggerBrowsable(DebuggerBrowsableState.Never)]
-        private NestedEnumAttributeType ContentField;
+        private NestedEnumElementType ContentField;
         
-        private static readonly System.Xml.Linq.XName xName = System.Xml.Linq.XName.Get("Element4", "http://linqtoxsd.schemas.org/test/enums-test.xsd");
-        
-		public static explicit operator Element4(XElement xe) { return XTypedServices.ToXTypedElement<Element4, NestedEnumAttributeType>(xe,LinqToXsdTypeManager.Instance as ILinqToXsdTypeManager); }
-        
-        public Element4() {
-            SetInnerType(new NestedEnumAttributeType());
-        }
-        
-        public Element4(NestedEnumAttributeType content) {
-            SetInnerType(content);
+        public Element3() {
+            SetInnerType(new NestedEnumElementType());
         }
         
         public override XElement Untyped {
@@ -849,25 +1069,56 @@ namespace LinqToXsd.Schemas.Test.EnumsTypes {
             }
         }
         
-        public virtual NestedEnumAttributeType Content {
+        public virtual NestedEnumElementType Content {
             get {
                 return ContentField;
             }
         }
         
+        private void SetInnerType(NestedEnumElementType ContentField) {
+            this.ContentField = ((NestedEnumElementType)(XTypedServices.GetCloneIfRooted(ContentField)));
+            XTypedServices.SetName(this, this.ContentField);
+        }
+        
+        public Element3(NestedEnumElementType content) {
+            SetInnerType(content);
+        }
+        
         /// <summary>
         /// <para>
-        /// Occurrence: optional
+        /// Occurrence: required
+        /// </para>
+        /// <para>
+        /// Regular expression: (Language, Invalid)
         /// </para>
         /// </summary>
-        public virtual LinqToXsd.Schemas.Test.EnumsTypes.NestedEnumAttributeType.LanguageEnum? language {
+        public virtual LinqToXsd.Schemas.Test.EnumsTypes.NestedEnumElementType.LanguageEnum Language {
             get {
-                return this.ContentField.language;
+                return this.ContentField.Language;
             }
             set {
-                this.ContentField.language = value;
+                this.ContentField.Language = value;
             }
         }
+        
+        /// <summary>
+        /// <para>
+        /// Occurrence: required
+        /// </para>
+        /// <para>
+        /// Regular expression: (Language, Invalid)
+        /// </para>
+        /// </summary>
+        public virtual LinqToXsd.Schemas.Test.EnumsTypes.NestedEnumElementType.InvalidEnum Invalid {
+            get {
+                return this.ContentField.Invalid;
+            }
+            set {
+                this.ContentField.Invalid = value;
+            }
+        }
+        
+        private static readonly System.Xml.Linq.XName xName = System.Xml.Linq.XName.Get("Element3", "http://linqtoxsd.schemas.org/test/enums-test.xsd");
         
         Dictionary<System.Xml.Linq.XName, System.Type> IXMetaData.LocalElementsDictionary {
             get {
@@ -880,6 +1131,10 @@ namespace LinqToXsd.Schemas.Test.EnumsTypes {
             get {
                 return this.Content;
             }
+        }
+        
+        ContentModelEntity IXMetaData.GetContentModel() {
+            return ContentModelEntity.Default;
         }
         
         [DebuggerBrowsable(DebuggerBrowsableState.Never)]
@@ -902,6 +1157,9 @@ namespace LinqToXsd.Schemas.Test.EnumsTypes {
                 return LinqToXsdTypeManager.Instance;
             }
         }
+    }
+    
+    public partial class Element4 : XTypedElement, IXMetaData {
         
         public void Save(string xmlFile) {
             XTypedServices.Save(xmlFile, Untyped);
@@ -927,35 +1185,17 @@ namespace LinqToXsd.Schemas.Test.EnumsTypes {
             return XTypedServices.Parse<Element4, NestedEnumAttributeType>(xml, LinqToXsdTypeManager.Instance);
         }
         
+		public static explicit operator Element4(XElement xe) { return XTypedServices.ToXTypedElement<Element4, NestedEnumAttributeType>(xe,LinqToXsdTypeManager.Instance as ILinqToXsdTypeManager); }
+        
         public override XTypedElement Clone() {
             return new Element4(((NestedEnumAttributeType)(this.Content.Clone())));
         }
         
-        private void SetInnerType(NestedEnumAttributeType ContentField) {
-            this.ContentField = ((NestedEnumAttributeType)(XTypedServices.GetCloneIfRooted(ContentField)));
-            XTypedServices.SetName(this, this.ContentField);
-        }
-        
-        ContentModelEntity IXMetaData.GetContentModel() {
-            return ContentModelEntity.Default;
-        }
-    }
-    
-    public partial class Element5 : XTypedElement, IXMetaData {
-        
         [DebuggerBrowsable(DebuggerBrowsableState.Never)]
-        private NestedDerivedEnumAttributeType ContentField;
+        private NestedEnumAttributeType ContentField;
         
-        private static readonly System.Xml.Linq.XName xName = System.Xml.Linq.XName.Get("Element5", "http://linqtoxsd.schemas.org/test/enums-test.xsd");
-        
-		public static explicit operator Element5(XElement xe) { return XTypedServices.ToXTypedElement<Element5, NestedDerivedEnumAttributeType>(xe,LinqToXsdTypeManager.Instance as ILinqToXsdTypeManager); }
-        
-        public Element5() {
-            SetInnerType(new NestedDerivedEnumAttributeType());
-        }
-        
-        public Element5(NestedDerivedEnumAttributeType content) {
-            SetInnerType(content);
+        public Element4() {
+            SetInnerType(new NestedEnumAttributeType());
         }
         
         public override XElement Untyped {
@@ -968,9 +1208,32 @@ namespace LinqToXsd.Schemas.Test.EnumsTypes {
             }
         }
         
-        public virtual NestedDerivedEnumAttributeType Content {
+        public virtual NestedEnumAttributeType Content {
             get {
                 return ContentField;
+            }
+        }
+        
+        private void SetInnerType(NestedEnumAttributeType ContentField) {
+            this.ContentField = ((NestedEnumAttributeType)(XTypedServices.GetCloneIfRooted(ContentField)));
+            XTypedServices.SetName(this, this.ContentField);
+        }
+        
+        public Element4(NestedEnumAttributeType content) {
+            SetInnerType(content);
+        }
+        
+        /// <summary>
+        /// <para>
+        /// Occurrence: optional
+        /// </para>
+        /// </summary>
+        public virtual LinqToXsd.Schemas.Test.EnumsTypes.NestedEnumAttributeType.LanguageEnum? language {
+            get {
+                return this.ContentField.language;
+            }
+            set {
+                this.ContentField.language = value;
             }
         }
         
@@ -979,14 +1242,16 @@ namespace LinqToXsd.Schemas.Test.EnumsTypes {
         /// Occurrence: optional
         /// </para>
         /// </summary>
-        public virtual LinqToXsd.Schemas.Test.EnumsTypes.NestedDerivedEnumAttributeType.AdditionalLanguageEnum? additionalLanguage {
+        public virtual LinqToXsd.Schemas.Test.EnumsTypes.NestedEnumAttributeType.InvalidEnum? invalid {
             get {
-                return this.ContentField.additionalLanguage;
+                return this.ContentField.invalid;
             }
             set {
-                this.ContentField.additionalLanguage = value;
+                this.ContentField.invalid = value;
             }
         }
+        
+        private static readonly System.Xml.Linq.XName xName = System.Xml.Linq.XName.Get("Element4", "http://linqtoxsd.schemas.org/test/enums-test.xsd");
         
         Dictionary<System.Xml.Linq.XName, System.Type> IXMetaData.LocalElementsDictionary {
             get {
@@ -999,6 +1264,10 @@ namespace LinqToXsd.Schemas.Test.EnumsTypes {
             get {
                 return this.Content;
             }
+        }
+        
+        ContentModelEntity IXMetaData.GetContentModel() {
+            return ContentModelEntity.Default;
         }
         
         [DebuggerBrowsable(DebuggerBrowsableState.Never)]
@@ -1021,6 +1290,9 @@ namespace LinqToXsd.Schemas.Test.EnumsTypes {
                 return LinqToXsdTypeManager.Instance;
             }
         }
+    }
+    
+    public partial class Element5 : XTypedElement, IXMetaData {
         
         public void Save(string xmlFile) {
             XTypedServices.Save(xmlFile, Untyped);
@@ -1046,8 +1318,33 @@ namespace LinqToXsd.Schemas.Test.EnumsTypes {
             return XTypedServices.Parse<Element5, NestedDerivedEnumAttributeType>(xml, LinqToXsdTypeManager.Instance);
         }
         
+		public static explicit operator Element5(XElement xe) { return XTypedServices.ToXTypedElement<Element5, NestedDerivedEnumAttributeType>(xe,LinqToXsdTypeManager.Instance as ILinqToXsdTypeManager); }
+        
         public override XTypedElement Clone() {
             return new Element5(((NestedDerivedEnumAttributeType)(this.Content.Clone())));
+        }
+        
+        [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+        private NestedDerivedEnumAttributeType ContentField;
+        
+        public Element5() {
+            SetInnerType(new NestedDerivedEnumAttributeType());
+        }
+        
+        public override XElement Untyped {
+            get {
+                return base.Untyped;
+            }
+            set {
+                base.Untyped = value;
+                this.ContentField.Untyped = value;
+            }
+        }
+        
+        public virtual NestedDerivedEnumAttributeType Content {
+            get {
+                return ContentField;
+            }
         }
         
         private void SetInnerType(NestedDerivedEnumAttributeType ContentField) {
@@ -1055,32 +1352,143 @@ namespace LinqToXsd.Schemas.Test.EnumsTypes {
             XTypedServices.SetName(this, this.ContentField);
         }
         
+        public Element5(NestedDerivedEnumAttributeType content) {
+            SetInnerType(content);
+        }
+        
+        /// <summary>
+        /// <para>
+        /// Occurrence: optional
+        /// </para>
+        /// </summary>
+        public virtual LinqToXsd.Schemas.Test.EnumsTypes.NestedDerivedEnumAttributeType.AdditionalLanguageEnum? additionalLanguage {
+            get {
+                return this.ContentField.additionalLanguage;
+            }
+            set {
+                this.ContentField.additionalLanguage = value;
+            }
+        }
+        
+        /// <summary>
+        /// <para>
+        /// Occurrence: optional
+        /// </para>
+        /// </summary>
+        public virtual LinqToXsd.Schemas.Test.EnumsTypes.NestedDerivedEnumAttributeType.AdditionalInvalidEnum? additionalInvalid {
+            get {
+                return this.ContentField.additionalInvalid;
+            }
+            set {
+                this.ContentField.additionalInvalid = value;
+            }
+        }
+        
+        /// <summary>
+        /// <para>
+        /// Occurrence: optional
+        /// </para>
+        /// </summary>
+        public virtual LinqToXsd.Schemas.Test.EnumsTypes.NestedEnumAttributeType.LanguageEnum? language {
+            get {
+                return this.ContentField.language;
+            }
+            set {
+                this.ContentField.language = value;
+            }
+        }
+        
+        /// <summary>
+        /// <para>
+        /// Occurrence: optional
+        /// </para>
+        /// </summary>
+        public virtual LinqToXsd.Schemas.Test.EnumsTypes.NestedEnumAttributeType.InvalidEnum? invalid {
+            get {
+                return this.ContentField.invalid;
+            }
+            set {
+                this.ContentField.invalid = value;
+            }
+        }
+        
+        private static readonly System.Xml.Linq.XName xName = System.Xml.Linq.XName.Get("Element5", "http://linqtoxsd.schemas.org/test/enums-test.xsd");
+        
+        Dictionary<System.Xml.Linq.XName, System.Type> IXMetaData.LocalElementsDictionary {
+            get {
+                IXMetaData schemaMetaData = ((IXMetaData)(this.Content));
+                return schemaMetaData.LocalElementsDictionary;
+            }
+        }
+        
+        XTypedElement IXMetaData.Content {
+            get {
+                return this.Content;
+            }
+        }
+        
         ContentModelEntity IXMetaData.GetContentModel() {
             return ContentModelEntity.Default;
+        }
+        
+        [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+        System.Xml.Linq.XName IXMetaData.SchemaName {
+            get {
+                return xName;
+            }
+        }
+        
+        [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+        SchemaOrigin IXMetaData.TypeOrigin {
+            get {
+                return SchemaOrigin.Element;
+            }
+        }
+        
+        [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+        ILinqToXsdTypeManager IXMetaData.TypeManager {
+            get {
+                return LinqToXsdTypeManager.Instance;
+            }
         }
     }
     
     public class LinqToXsdTypeManager : ILinqToXsdTypeManager {
         
+        private LinqToXsdTypeManager() {
+        }
+        
         private static Dictionary<System.Xml.Linq.XName, System.Type> typeDictionary = new Dictionary<System.Xml.Linq.XName, System.Type>();
+        
+        private static void BuildTypeDictionary() {
+            typeDictionary.Add(System.Xml.Linq.XName.Get("GlobalEnumElementType", "http://linqtoxsd.schemas.org/test/enums-test.xsd"), typeof(global::LinqToXsd.Schemas.Test.EnumsTypes.GlobalEnumElementType));
+            typeDictionary.Add(System.Xml.Linq.XName.Get("GlobalEnumAttributeType", "http://linqtoxsd.schemas.org/test/enums-test.xsd"), typeof(global::LinqToXsd.Schemas.Test.EnumsTypes.GlobalEnumAttributeType));
+            typeDictionary.Add(System.Xml.Linq.XName.Get("NestedEnumElementType", "http://linqtoxsd.schemas.org/test/enums-test.xsd"), typeof(global::LinqToXsd.Schemas.Test.EnumsTypes.NestedEnumElementType));
+            typeDictionary.Add(System.Xml.Linq.XName.Get("NestedEnumAttributeType", "http://linqtoxsd.schemas.org/test/enums-test.xsd"), typeof(global::LinqToXsd.Schemas.Test.EnumsTypes.NestedEnumAttributeType));
+            typeDictionary.Add(System.Xml.Linq.XName.Get("NestedDerivedEnumAttributeType", "http://linqtoxsd.schemas.org/test/enums-test.xsd"), typeof(global::LinqToXsd.Schemas.Test.EnumsTypes.NestedDerivedEnumAttributeType));
+        }
         
         private static Dictionary<System.Xml.Linq.XName, System.Type> elementDictionary = new Dictionary<System.Xml.Linq.XName, System.Type>();
         
+        private static void BuildElementDictionary() {
+            elementDictionary.Add(System.Xml.Linq.XName.Get("Element1", "http://linqtoxsd.schemas.org/test/enums-test.xsd"), typeof(global::LinqToXsd.Schemas.Test.EnumsTypes.Element1));
+            elementDictionary.Add(System.Xml.Linq.XName.Get("Element2", "http://linqtoxsd.schemas.org/test/enums-test.xsd"), typeof(global::LinqToXsd.Schemas.Test.EnumsTypes.Element2));
+            elementDictionary.Add(System.Xml.Linq.XName.Get("Element3", "http://linqtoxsd.schemas.org/test/enums-test.xsd"), typeof(global::LinqToXsd.Schemas.Test.EnumsTypes.Element3));
+            elementDictionary.Add(System.Xml.Linq.XName.Get("Element4", "http://linqtoxsd.schemas.org/test/enums-test.xsd"), typeof(global::LinqToXsd.Schemas.Test.EnumsTypes.Element4));
+            elementDictionary.Add(System.Xml.Linq.XName.Get("Element5", "http://linqtoxsd.schemas.org/test/enums-test.xsd"), typeof(global::LinqToXsd.Schemas.Test.EnumsTypes.Element5));
+        }
+        
         private static Dictionary<System.Type, System.Type> wrapperDictionary = new Dictionary<System.Type, System.Type>();
         
+        private static void BuildWrapperDictionary() {
+            wrapperDictionary.Add(typeof(LinqToXsd.Schemas.Test.EnumsTypes.Element1), typeof(global::LinqToXsd.Schemas.Test.EnumsTypes.GlobalEnumElementType));
+            wrapperDictionary.Add(typeof(LinqToXsd.Schemas.Test.EnumsTypes.Element2), typeof(global::LinqToXsd.Schemas.Test.EnumsTypes.GlobalEnumAttributeType));
+            wrapperDictionary.Add(typeof(LinqToXsd.Schemas.Test.EnumsTypes.Element3), typeof(global::LinqToXsd.Schemas.Test.EnumsTypes.NestedEnumElementType));
+            wrapperDictionary.Add(typeof(LinqToXsd.Schemas.Test.EnumsTypes.Element4), typeof(global::LinqToXsd.Schemas.Test.EnumsTypes.NestedEnumAttributeType));
+            wrapperDictionary.Add(typeof(LinqToXsd.Schemas.Test.EnumsTypes.Element5), typeof(global::LinqToXsd.Schemas.Test.EnumsTypes.NestedDerivedEnumAttributeType));
+        }
+        
         private static XmlSchemaSet schemaSet;
-        
-        [DebuggerBrowsable(DebuggerBrowsableState.Never)]
-        private static LinqToXsdTypeManager typeManagerSingleton = new LinqToXsdTypeManager();
-        
-        static LinqToXsdTypeManager() {
-            BuildTypeDictionary();
-            BuildElementDictionary();
-            BuildWrapperDictionary();
-        }
-        
-        private LinqToXsdTypeManager() {
-        }
         
         XmlSchemaSet ILinqToXsdTypeManager.Schemas {
             get {
@@ -1093,6 +1501,10 @@ namespace LinqToXsd.Schemas.Test.EnumsTypes {
             set {
                 schemaSet = value;
             }
+        }
+        
+        protected internal static void AddSchemas(XmlSchemaSet schemas) {
+            schemas.Add(schemaSet);
         }
         
         Dictionary<System.Xml.Linq.XName, System.Type> ILinqToXsdTypeManager.GlobalTypeDictionary {
@@ -1113,42 +1525,23 @@ namespace LinqToXsd.Schemas.Test.EnumsTypes {
             }
         }
         
-        public static LinqToXsdTypeManager Instance {
-            get {
-                return typeManagerSingleton;
-            }
-        }
-        
-        private static void BuildTypeDictionary() {
-            typeDictionary.Add(System.Xml.Linq.XName.Get("GlobalEnumElementType", "http://linqtoxsd.schemas.org/test/enums-test.xsd"), typeof(global::LinqToXsd.Schemas.Test.EnumsTypes.GlobalEnumElementType));
-            typeDictionary.Add(System.Xml.Linq.XName.Get("GlobalEnumAttributeType", "http://linqtoxsd.schemas.org/test/enums-test.xsd"), typeof(global::LinqToXsd.Schemas.Test.EnumsTypes.GlobalEnumAttributeType));
-            typeDictionary.Add(System.Xml.Linq.XName.Get("NestedEnumElementType", "http://linqtoxsd.schemas.org/test/enums-test.xsd"), typeof(global::LinqToXsd.Schemas.Test.EnumsTypes.NestedEnumElementType));
-            typeDictionary.Add(System.Xml.Linq.XName.Get("NestedEnumAttributeType", "http://linqtoxsd.schemas.org/test/enums-test.xsd"), typeof(global::LinqToXsd.Schemas.Test.EnumsTypes.NestedEnumAttributeType));
-            typeDictionary.Add(System.Xml.Linq.XName.Get("NestedDerivedEnumAttributeType", "http://linqtoxsd.schemas.org/test/enums-test.xsd"), typeof(global::LinqToXsd.Schemas.Test.EnumsTypes.NestedDerivedEnumAttributeType));
-        }
-        
-        private static void BuildElementDictionary() {
-            elementDictionary.Add(System.Xml.Linq.XName.Get("Element1", "http://linqtoxsd.schemas.org/test/enums-test.xsd"), typeof(global::LinqToXsd.Schemas.Test.EnumsTypes.Element1));
-            elementDictionary.Add(System.Xml.Linq.XName.Get("Element2", "http://linqtoxsd.schemas.org/test/enums-test.xsd"), typeof(global::LinqToXsd.Schemas.Test.EnumsTypes.Element2));
-            elementDictionary.Add(System.Xml.Linq.XName.Get("Element3", "http://linqtoxsd.schemas.org/test/enums-test.xsd"), typeof(global::LinqToXsd.Schemas.Test.EnumsTypes.Element3));
-            elementDictionary.Add(System.Xml.Linq.XName.Get("Element4", "http://linqtoxsd.schemas.org/test/enums-test.xsd"), typeof(global::LinqToXsd.Schemas.Test.EnumsTypes.Element4));
-            elementDictionary.Add(System.Xml.Linq.XName.Get("Element5", "http://linqtoxsd.schemas.org/test/enums-test.xsd"), typeof(global::LinqToXsd.Schemas.Test.EnumsTypes.Element5));
-        }
-        
-        private static void BuildWrapperDictionary() {
-            wrapperDictionary.Add(typeof(LinqToXsd.Schemas.Test.EnumsTypes.Element1), typeof(global::LinqToXsd.Schemas.Test.EnumsTypes.GlobalEnumElementType));
-            wrapperDictionary.Add(typeof(LinqToXsd.Schemas.Test.EnumsTypes.Element2), typeof(global::LinqToXsd.Schemas.Test.EnumsTypes.GlobalEnumAttributeType));
-            wrapperDictionary.Add(typeof(LinqToXsd.Schemas.Test.EnumsTypes.Element3), typeof(global::LinqToXsd.Schemas.Test.EnumsTypes.NestedEnumElementType));
-            wrapperDictionary.Add(typeof(LinqToXsd.Schemas.Test.EnumsTypes.Element4), typeof(global::LinqToXsd.Schemas.Test.EnumsTypes.NestedEnumAttributeType));
-            wrapperDictionary.Add(typeof(LinqToXsd.Schemas.Test.EnumsTypes.Element5), typeof(global::LinqToXsd.Schemas.Test.EnumsTypes.NestedDerivedEnumAttributeType));
-        }
-        
-        protected internal static void AddSchemas(XmlSchemaSet schemas) {
-            schemas.Add(schemaSet);
+        static LinqToXsdTypeManager() {
+            BuildTypeDictionary();
+            BuildElementDictionary();
+            BuildWrapperDictionary();
         }
         
         public static System.Type GetRootType() {
             return elementDictionary[System.Xml.Linq.XName.Get("Element1", "http://linqtoxsd.schemas.org/test/enums-test.xsd")];
+        }
+        
+        [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+        private static LinqToXsdTypeManager typeManagerSingleton = new LinqToXsdTypeManager();
+        
+        public static LinqToXsdTypeManager Instance {
+            get {
+                return typeManagerSingleton;
+            }
         }
     }
     
@@ -1160,55 +1553,7 @@ namespace LinqToXsd.Schemas.Test.EnumsTypes {
         [DebuggerBrowsable(DebuggerBrowsableState.Never)]
         private XTypedElement rootObject;
         
-
-		public Element1 Element1 {  get {return rootObject as Element1; } }
-
-		public Element2 Element2 {  get {return rootObject as Element2; } }
-
-		public Element3 Element3 {  get {return rootObject as Element3; } }
-
-		public Element4 Element4 {  get {return rootObject as Element4; } }
-
-		public Element5 Element5 {  get {return rootObject as Element5; } }
-        
         private XRootNamespace() {
-        }
-        
-        public XRootNamespace(Element1 root) {
-            this.doc = new XDocument(root.Untyped);
-            this.rootObject = root;
-        }
-        
-        public XRootNamespace(Element2 root) {
-            this.doc = new XDocument(root.Untyped);
-            this.rootObject = root;
-        }
-        
-        public XRootNamespace(Element3 root) {
-            this.doc = new XDocument(root.Untyped);
-            this.rootObject = root;
-        }
-        
-        public XRootNamespace(Element4 root) {
-            this.doc = new XDocument(root.Untyped);
-            this.rootObject = root;
-        }
-        
-        public XRootNamespace(Element5 root) {
-            this.doc = new XDocument(root.Untyped);
-            this.rootObject = root;
-        }
-        
-        public virtual XDocument XDocument {
-            get {
-                return doc;
-            }
-        }
-        
-        public virtual XTypedElement Root {
-            get {
-                return rootObject;
-            }
         }
         
         public static XRootNamespace Load(string xmlFile) {
@@ -1307,54 +1652,6 @@ namespace LinqToXsd.Schemas.Test.EnumsTypes {
         public virtual void Save(string fileName, SaveOptions options) {
             doc.Save(fileName, options);
         }
-    }
-    
-    public partial class XRoot {
-        
-        [DebuggerBrowsable(DebuggerBrowsableState.Never)]
-        private XDocument doc;
-        
-        [DebuggerBrowsable(DebuggerBrowsableState.Never)]
-        private XTypedElement rootObject;
-        
-
-		public global::LinqToXsd.Schemas.Test.EnumsTypes.Element1 Element1 {  get {return rootObject as global::LinqToXsd.Schemas.Test.EnumsTypes.Element1; } }
-
-		public global::LinqToXsd.Schemas.Test.EnumsTypes.Element2 Element2 {  get {return rootObject as global::LinqToXsd.Schemas.Test.EnumsTypes.Element2; } }
-
-		public global::LinqToXsd.Schemas.Test.EnumsTypes.Element3 Element3 {  get {return rootObject as global::LinqToXsd.Schemas.Test.EnumsTypes.Element3; } }
-
-		public global::LinqToXsd.Schemas.Test.EnumsTypes.Element4 Element4 {  get {return rootObject as global::LinqToXsd.Schemas.Test.EnumsTypes.Element4; } }
-
-		public global::LinqToXsd.Schemas.Test.EnumsTypes.Element5 Element5 {  get {return rootObject as global::LinqToXsd.Schemas.Test.EnumsTypes.Element5; } }
-        
-        private XRoot() {
-        }
-        
-        public XRoot(global::LinqToXsd.Schemas.Test.EnumsTypes.Element1 root) {
-            this.doc = new XDocument(root.Untyped);
-            this.rootObject = root;
-        }
-        
-        public XRoot(global::LinqToXsd.Schemas.Test.EnumsTypes.Element2 root) {
-            this.doc = new XDocument(root.Untyped);
-            this.rootObject = root;
-        }
-        
-        public XRoot(global::LinqToXsd.Schemas.Test.EnumsTypes.Element3 root) {
-            this.doc = new XDocument(root.Untyped);
-            this.rootObject = root;
-        }
-        
-        public XRoot(global::LinqToXsd.Schemas.Test.EnumsTypes.Element4 root) {
-            this.doc = new XDocument(root.Untyped);
-            this.rootObject = root;
-        }
-        
-        public XRoot(global::LinqToXsd.Schemas.Test.EnumsTypes.Element5 root) {
-            this.doc = new XDocument(root.Untyped);
-            this.rootObject = root;
-        }
         
         public virtual XDocument XDocument {
             get {
@@ -1366,6 +1663,58 @@ namespace LinqToXsd.Schemas.Test.EnumsTypes {
             get {
                 return rootObject;
             }
+        }
+        
+        public XRootNamespace(Element1 root) {
+            this.doc = new XDocument(root.Untyped);
+            this.rootObject = root;
+        }
+        
+
+		public Element1 Element1 {  get {return rootObject as Element1; } }
+        
+        public XRootNamespace(Element2 root) {
+            this.doc = new XDocument(root.Untyped);
+            this.rootObject = root;
+        }
+        
+
+		public Element2 Element2 {  get {return rootObject as Element2; } }
+        
+        public XRootNamespace(Element3 root) {
+            this.doc = new XDocument(root.Untyped);
+            this.rootObject = root;
+        }
+        
+
+		public Element3 Element3 {  get {return rootObject as Element3; } }
+        
+        public XRootNamespace(Element4 root) {
+            this.doc = new XDocument(root.Untyped);
+            this.rootObject = root;
+        }
+        
+
+		public Element4 Element4 {  get {return rootObject as Element4; } }
+        
+        public XRootNamespace(Element5 root) {
+            this.doc = new XDocument(root.Untyped);
+            this.rootObject = root;
+        }
+        
+
+		public Element5 Element5 {  get {return rootObject as Element5; } }
+    }
+    
+    public partial class XRoot {
+        
+        [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+        private XDocument doc;
+        
+        [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+        private XTypedElement rootObject;
+        
+        private XRoot() {
         }
         
         public static XRoot Load(string xmlFile) {
@@ -1464,5 +1813,57 @@ namespace LinqToXsd.Schemas.Test.EnumsTypes {
         public virtual void Save(string fileName, SaveOptions options) {
             doc.Save(fileName, options);
         }
+        
+        public virtual XDocument XDocument {
+            get {
+                return doc;
+            }
+        }
+        
+        public virtual XTypedElement Root {
+            get {
+                return rootObject;
+            }
+        }
+        
+        public XRoot(global::LinqToXsd.Schemas.Test.EnumsTypes.Element1 root) {
+            this.doc = new XDocument(root.Untyped);
+            this.rootObject = root;
+        }
+        
+
+		public global::LinqToXsd.Schemas.Test.EnumsTypes.Element1 Element1 {  get {return rootObject as global::LinqToXsd.Schemas.Test.EnumsTypes.Element1; } }
+        
+        public XRoot(global::LinqToXsd.Schemas.Test.EnumsTypes.Element2 root) {
+            this.doc = new XDocument(root.Untyped);
+            this.rootObject = root;
+        }
+        
+
+		public global::LinqToXsd.Schemas.Test.EnumsTypes.Element2 Element2 {  get {return rootObject as global::LinqToXsd.Schemas.Test.EnumsTypes.Element2; } }
+        
+        public XRoot(global::LinqToXsd.Schemas.Test.EnumsTypes.Element3 root) {
+            this.doc = new XDocument(root.Untyped);
+            this.rootObject = root;
+        }
+        
+
+		public global::LinqToXsd.Schemas.Test.EnumsTypes.Element3 Element3 {  get {return rootObject as global::LinqToXsd.Schemas.Test.EnumsTypes.Element3; } }
+        
+        public XRoot(global::LinqToXsd.Schemas.Test.EnumsTypes.Element4 root) {
+            this.doc = new XDocument(root.Untyped);
+            this.rootObject = root;
+        }
+        
+
+		public global::LinqToXsd.Schemas.Test.EnumsTypes.Element4 Element4 {  get {return rootObject as global::LinqToXsd.Schemas.Test.EnumsTypes.Element4; } }
+        
+        public XRoot(global::LinqToXsd.Schemas.Test.EnumsTypes.Element5 root) {
+            this.doc = new XDocument(root.Untyped);
+            this.rootObject = root;
+        }
+        
+
+		public global::LinqToXsd.Schemas.Test.EnumsTypes.Element5 Element5 {  get {return rootObject as global::LinqToXsd.Schemas.Test.EnumsTypes.Element5; } }
     }
 }

--- a/LinqToXsd/Properties/launchSettings.json
+++ b/LinqToXsd/Properties/launchSettings.json
@@ -3,6 +3,12 @@
     "LinqToXsd": {
       "commandName": "Project"
     },
+    "EnumInvalidChars": {
+      "commandName": "Project",
+      "commandLineArgs": "gen EnumsTest.xsd -a",
+      "workingDirectory": "..\\GeneratedSchemaLibraries\\EnumsTest",
+      "hotReloadEnabled": false
+    },
     "W3C XSD": {
       "commandName": "Project",
       "commandLineArgs": "gen \"W3C XMLSchema v1.xsd\" -a",

--- a/Version.props
+++ b/Version.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-    <Version>3.4.10</Version>
+    <Version>3.4.11</Version>
     <VersionSuffix>$(VersionSuffix)</VersionSuffix>
     <Version Condition=" '$(VersionSuffix)' != '' ">$(Version)-$(VersionSuffix)</Version>
   </PropertyGroup>

--- a/XObjectsCode/Src/ClrPropertyInfo.cs
+++ b/XObjectsCode/Src/ClrPropertyInfo.cs
@@ -551,7 +551,7 @@ namespace Xml.Schema.Linq.CodeGen
                     break;
 
                 case SchemaOrigin.Attribute:
-                    validation = false;
+                    validation = this.IsEnum;
                     setMethodName += "Attribute";
                     break;
 
@@ -593,13 +593,14 @@ namespace Xml.Schema.Linq.CodeGen
                 if (xNameParm)
                 {
                     var setValue = CodeDomHelper.SetValue();
+                    // this.SetElementWithValidation(<PropertyName>XName, <valueExpr>, "<PropertyName>", global::LinqToXsd.Schemas.Test.EnumsTypes.LanguageCodeEnumValidator.TypeDefinition);
                     setWithValidation = CodeDomHelper.CreateMethodCall(
-                        CodeDomHelper.This(),
-                        setMethodName + "WithValidation",
-                        xNameExpression,
+                        CodeDomHelper.This(),                       // this
+                        setMethodName + "WithValidation",           // SetElementWithValidation
+                        xNameExpression,                            // <PropertyName>XName
                         valueExpr,
-                        new CodePrimitiveExpression(PropertyName),
-                        GetSimpleTypeClassExpression());
+                        new CodePrimitiveExpression(PropertyName),  // "<PropertyName>"
+                        GetSimpleTypeClassExpression());            // global::LinqToXsd.Schemas.Test.EnumsTypes.LanguageCodeEnumValidator.TypeDefinition
                 }
                 else
                 {
@@ -853,6 +854,7 @@ namespace Xml.Schema.Linq.CodeGen
                     }
                     else
                     {
+                        // XTypedServices.ParseValue<string>
                         parseMethodName = Constants.ParseValue;
                         if (IsEnum) {
                             if (TypeReference.SchemaObject is XmlSchemaSimpleType simpleSchemaType) {
@@ -861,17 +863,26 @@ namespace Xml.Schema.Linq.CodeGen
                         }
                     }
 
-                    returnExp = CodeDomHelper.CreateGenericMethodCall(
-                        CodeDomHelper.CreateTypeReferenceExp(Constants.XTypedServices),
-                        parseMethodName,
-                        parseType,
-                        returnValueExp,
-                        simpleTypeExpression);
-
                     if (IsEnum)
                     {
+                        // XTypedServices.ParseValue(x, XmlSchemaType.GetBuiltInSimpleType(XmlTypeCode.NmToken).Datatype, global::LinqToXsd.Schemas.Test.EnumsTypes.LanguageCodeEnumValidator.TypeDefinition)
+                        returnExp = CodeDomHelper.CreateMethodCall(
+                             CodeDomHelper.CreateTypeReferenceExp(Constants.XTypedServices),    // XTypedServices
+                             parseMethodName,                                                   // ParseValue
+                             returnValueExp,                                                    // x
+                             simpleTypeExpression,                                              // XmlSchemaType.GetBuiltInSimpleType(XmlTypeCode.NmToken).Datatype
+                             GetSimpleTypeClassExpression());                                   // global::LinqToXsd.Schemas.Test.EnumsTypes.LanguageCodeEnumValidator.TypeDefinition
                         // (EnumType) Enum.Parse(typeof(EnumType), returnExp)
                         returnExp = CodeDomHelper.CreateParseEnumCall(this.TypeReference.ClrFullTypeName, returnExp);
+                    }
+                    else
+                    {
+                        returnExp = CodeDomHelper.CreateGenericMethodCall(
+                            CodeDomHelper.CreateTypeReferenceExp(Constants.XTypedServices),
+                            parseMethodName,
+                            parseType,
+                            returnValueExp,
+                            simpleTypeExpression);
                     }
                 }
             }

--- a/XObjectsCode/Src/CompiledFacets.cs
+++ b/XObjectsCode/Src/CompiledFacets.cs
@@ -97,6 +97,7 @@ namespace Xml.Schema.Linq
 
         public void compileFacets(XmlSchemaSimpleType simpleType)
         {
+            var isEnum = simpleType.IsEnum();
             XmlSchemaSimpleType type = simpleType;
             XmlSchemaSimpleType enumSimpleType = null; //simpletype that has most restricted enums.
             flags = 0;
@@ -151,8 +152,15 @@ namespace Xml.Schema.Linq
                                 nameTable = new NameTable();
                             }
                             var value = type.BaseXmlSchemaType.Datatype.ParseValue(s: facet.Value, nameTable: nameTable, nsmgr: null);
-                            var enumFacet = new EnumFacet(value.ToString());
-                            enumerations.Add(enumFacet.ToString());
+                            if (isEnum)
+                            {
+                                var enumFacet = new EnumFacet(value.ToString());
+                                enumerations.Add(enumFacet.ToString());
+                            }
+                            else
+                            {
+                                enumerations.Add(value);
+                            }
                         }
                         else if (facet is XmlSchemaPatternFacet)
                         {

--- a/XObjectsCode/Src/CompiledFacets.cs
+++ b/XObjectsCode/Src/CompiledFacets.cs
@@ -151,7 +151,8 @@ namespace Xml.Schema.Linq
                                 nameTable = new NameTable();
                             }
                             var value = type.BaseXmlSchemaType.Datatype.ParseValue(s: facet.Value, nameTable: nameTable, nsmgr: null);
-                            enumerations.Add(value);
+                            var enumFacet = new EnumFacet(value.ToString());
+                            enumerations.Add(enumFacet.ToString());
                         }
                         else if (facet is XmlSchemaPatternFacet)
                         {

--- a/XObjectsCode/Src/EnumFacet.cs
+++ b/XObjectsCode/Src/EnumFacet.cs
@@ -1,0 +1,73 @@
+//Copyright (c) Microsoft Corporation.  All rights reserved.
+
+using System;
+using System.Globalization;
+using System.Linq;
+
+namespace Xml.Schema.Linq.CodeGen
+{
+    /// <summary>
+    /// Represents a facet of an enumeration, including its original value, validity, and a valid identifier.
+    /// </summary>
+    /// <remarks>This class is designed to handle enumeration member names, ensuring they conform to valid
+    /// identifier rules. If the provided value is not a valid identifier, a valid identifier is generated.<br/>
+    /// For invalid values, the string representation includes both the <see cref="Value"/> and <see cref="Member"/>
+    /// properties, separated by a colon.<br/>
+    /// This format is useful to convert invalid string values into valid enum values and vice versa.<br/>
+    /// See also the <see cref="EnumFacetMapping"/> class that is used during the runtime conversion.
+    /// </remarks>
+    public class EnumFacet
+    {
+        public EnumFacet(string value)
+        {
+            this.Value   = value;
+            this.IsValid = string.IsNullOrWhiteSpace(value) || CodeDomHelper.CodeProvider.IsValidIdentifier(value);
+            this.Member  = this.IsValid ? value : CreateValidIdentifier(value);
+        }
+
+        public string   Value   { get; }
+        public bool     IsValid { get; }
+        public string   Member  { get; }
+
+        public override string ToString() => this.IsValid ? this.Value : $"{this.Value}:{this.Member}";
+
+        private static string CreateValidIdentifier(string value)
+        {
+            if (string.IsNullOrEmpty(value)) return value;
+
+            var invalidChars = value
+                .GroupBy(char.GetUnicodeCategory)
+                .Where(g => !ValidUnicodeCategories.Contains(g.Key))
+                .SelectMany(_ => _)
+                .Distinct();
+
+            foreach(var c in invalidChars)
+            {
+                value = value.Replace(c, '_');
+            }
+            if (char.IsDigit(value[0]))
+            {
+                value = '_' + value;
+            }
+
+            value = CodeDomHelper.CodeProvider.CreateValidIdentifier(value);
+
+            return value;
+        }
+
+        // allows letter (Lu, Ll, Lt, Lm, or Nl), digit (Nd), connecting (Pc), combining (Mn or Mc), and formatting (Cf) categories
+        private static readonly UnicodeCategory[] ValidUnicodeCategories = new UnicodeCategory[]
+        {
+            UnicodeCategory.UppercaseLetter,
+            UnicodeCategory.LowercaseLetter,
+            UnicodeCategory.TitlecaseLetter,
+            UnicodeCategory.ModifierLetter,
+            UnicodeCategory.NonSpacingMark,
+            UnicodeCategory.SpacingCombiningMark,
+            UnicodeCategory.DecimalDigitNumber,
+            UnicodeCategory.LetterNumber,
+            UnicodeCategory.Format,
+            UnicodeCategory.ConnectorPunctuation,
+        };
+    }
+}

--- a/XObjectsCode/Src/SOMQueryExtensions.cs
+++ b/XObjectsCode/Src/SOMQueryExtensions.cs
@@ -143,7 +143,7 @@ namespace Xml.Schema.Linq.CodeGen
                     if (isEnum)
                     {
                         var facets = facetObjects.Cast<XmlSchemaEnumerationFacet>().Select(facet => facet.Value);
-                        isEnum = facets.All(facet => CodeDomHelper.CodeProvider.IsValidIdentifier(facet));
+                        isEnum = facets.All(facet => !string.IsNullOrWhiteSpace(facet));
                     }
                     return isEnum;
                 case XmlSchemaDatatypeVariety.List:
@@ -156,21 +156,25 @@ namespace Xml.Schema.Linq.CodeGen
             }
         }
 
-        public static IEnumerable<string> GetEnumFacets(this XmlSchemaType type)
+        public static IEnumerable<EnumFacet> GetEnumFacets(this XmlSchemaType type)
         {
             return type is XmlSchemaSimpleType simpleType
                 ? simpleType.GetEnumFacets()
-                : Enumerable.Empty<string>();
+                : Enumerable.Empty<EnumFacet>();
         }
-        public static IEnumerable<string> GetEnumFacets(this XmlSchemaSimpleType simpleType)
+        public static IEnumerable<EnumFacet> GetEnumFacets(this XmlSchemaSimpleType simpleType)
         {
             if (simpleType.Content is XmlSchemaSimpleTypeRestriction content)
             {
-                return content.Facets.Cast<XmlSchemaEnumerationFacet>().Select(facet => facet.Value).Cast<string>();
+                return content.Facets
+                    .Cast<XmlSchemaEnumerationFacet>()
+                    .Select(facet => facet.Value)
+                    .Distinct()
+                    .Select(facet => new EnumFacet(facet));
             }
             else
             {
-                return Enumerable.Empty<string>();
+                return Enumerable.Empty<EnumFacet>();
             }
         }
 

--- a/XObjectsCode/Src/TypeBuilder.cs
+++ b/XObjectsCode/Src/TypeBuilder.cs
@@ -413,7 +413,7 @@ namespace Xml.Schema.Linq.CodeGen
             enumTypeDecl.TypeAttributes = TypeAttributes.Sealed | typeVisibility;
             foreach (var facet in typeInfo.InnerType.GetEnumFacets())
             {
-                enumTypeDecl.Members.Add(new CodeMemberField(typeName, facet));
+                enumTypeDecl.Members.Add(new CodeMemberField(typeName, facet.Member));
             }
 
             if (clrTypeInfo != null)

--- a/XObjectsCore/API/XTypedServices.cs
+++ b/XObjectsCore/API/XTypedServices.cs
@@ -379,6 +379,17 @@ namespace Xml.Schema.Linq
             }
         }
 
+        public static string ParseValue(XElement element, XmlSchemaDatatype datatype, Xml.Schema.Linq.SimpleTypeValidator typeDef)
+        {
+            if (element == null)
+            {
+                return null;
+            }
+
+            var strValue  = ParseValue<string>(element.Value, element, datatype);
+            var enumFacet = typeDef.RestrictionFacets.GetEnumFacet(strValue);
+            return enumFacet != null ? enumFacet.Member : strValue;
+        }
         public static T ParseValue<T>(XElement element, XmlSchemaDatatype datatype)
         {
             if (element == null)
@@ -399,6 +410,17 @@ namespace Xml.Schema.Linq
             return ParseValue<T>(attribute.Value, attribute.Parent, datatype);
         }
 
+        public static string ParseValue(XAttribute attribute, XmlSchemaDatatype datatype, Xml.Schema.Linq.SimpleTypeValidator typeDef)
+        {
+            if (attribute == null)
+            {
+                return null;
+            }
+
+            var strValue  = ParseValue<string>(attribute.Value, attribute.Parent, datatype);
+            var enumFacet = typeDef.RestrictionFacets.GetEnumFacet(strValue);
+            return enumFacet != null ? enumFacet.Member : strValue;
+        }
         // Kept for backward compatibility with code generated in previous versions.
         // Current generator does not use this method anymore, as attributes with default properties
         // have `if (attr == null) return defaultValue` directly in getter to workaround enum parsing.

--- a/XObjectsCore/EnumFacetMapping.cs
+++ b/XObjectsCore/EnumFacetMapping.cs
@@ -1,0 +1,57 @@
+//Copyright (c) Microsoft Corporation.  All rights reserved.
+
+using System;
+using System.Xml.Schema;
+
+namespace Xml.Schema.Linq
+{
+    /// <summary>
+    /// Represents a mapping between an XML schema enumeration value and its corresponding CLR enum value.
+    /// </summary>
+    /// <remarks>This class is used to parse <see cref="RestrictionFacets.Enumeration"/> values, which may include
+    /// both the XML schema value and the CLR enum value separated by a colon (e.g., "Value:Member").
+    /// If no colon is present, the value is assumed to be the same as the member name.</remarks>
+    public class EnumFacetMapping
+    {
+        public static EnumFacetMapping Parse(object value)
+        {
+            if (value is string strValue)
+            {
+                return new EnumFacetMapping(strValue);
+            }
+            else if (value is XmlSchemaEnumerationFacet enumFacet)
+            {
+                return new EnumFacetMapping(enumFacet.Value);
+            }
+            else
+            {
+                throw new InvalidCastException($"Cannot convert {value} to {nameof(EnumFacetMapping)}");
+            }
+        }
+
+        private EnumFacetMapping(string value)
+        {
+            var atoms = value.Split(':');
+            if (atoms.Length > 1)
+            {
+                Value  = atoms[0];
+                Member = atoms[1];
+            }
+            else
+            {
+                Value = Member = value;
+            }
+        }
+
+        /// <summary>
+        /// Represents the XML schema value of the enumeration facet.
+        /// </summary>
+        public string Value  { get; }
+        /// <summary>
+        /// Represents the CLR enum member name corresponding to the XML schema value.
+        /// </summary>
+        public string Member { get; }
+
+        public override string ToString() => Value == Member ? Value : $"{Value}:{Member}";
+    }
+}

--- a/XObjectsTests/EnumsCodeGenTest.cs
+++ b/XObjectsTests/EnumsCodeGenTest.cs
@@ -1,12 +1,14 @@
 ﻿using System.Collections.Generic;
-using System.IO;
-using System.IO.Abstractions;
 using System.IO.Abstractions.TestingHelpers;
 using System.Linq;
+using System.Xml.Linq;
+
 using LinqToXsd.Schemas.Test.EnumsTypes;
+
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
+
 using NUnit.Framework;
 
 namespace Xml.Schema.Linq.Tests
@@ -30,7 +32,8 @@ namespace Xml.Schema.Linq.Tests
 
             var diags = Utilities.GetSyntaxAndCompilationDiagnostics(Tree);
             //Assert.AreEqual(0, diags.Length);
-            if (diags.Length > 0) {
+            if (diags.Length > 0)
+            {
                 Assert.Warn("Diagnostics for this test class's Tree should be 0");
             }
 
@@ -67,7 +70,7 @@ namespace Xml.Schema.Linq.Tests
         public void T3_UseNestedEnumForNestedEnumElement()
         {
             var type = GeneratedTypes.Single(type => type.Identifier.Text == nameof(NestedEnumElementType));
-            Assert.AreEqual(1, type.Members.OfType<EnumDeclarationSyntax>().Count());
+            Assert.AreEqual(2, type.Members.OfType<EnumDeclarationSyntax>().Count());
             var prop = type.Members.OfType<PropertyDeclarationSyntax>()
                 .SingleOrDefault(prop => prop.Identifier.Text == "Language");
             var getter =
@@ -82,7 +85,7 @@ namespace Xml.Schema.Linq.Tests
         public void T4_UseNestedEnumForNestedEnumAttribute()
         {
             var type = GeneratedTypes.Single(type => type.Identifier.Text == nameof(NestedEnumAttributeType));
-            Assert.AreEqual(1, type.Members.OfType<EnumDeclarationSyntax>().Count());
+            Assert.AreEqual(2, type.Members.OfType<EnumDeclarationSyntax>().Count());
             var prop = type.Members.OfType<PropertyDeclarationSyntax>()
                 .SingleOrDefault(prop => prop.Identifier.Text == "language");
             var getter =
@@ -97,7 +100,66 @@ namespace Xml.Schema.Linq.Tests
         public void T5_DoNotRedefineDerivedNestedEnumAttribute()
         {
             var type = GeneratedTypes.Single(type => type.Identifier.Text == nameof(NestedDerivedEnumAttributeType));
-            Assert.AreEqual(1, type.Members.OfType<EnumDeclarationSyntax>().Count());
+            Assert.AreEqual(2, type.Members.OfType<EnumDeclarationSyntax>().Count());
+        }
+
+        [Test]
+        public void T6_InvalidCharEnum()
+        {
+            var element1 = new GlobalEnumElementType
+            {
+                Language = LanguageCodeEnum.fr,
+                Invalid  = InvalidCharEnum.en_fr
+            };
+            Assert.AreEqual(LanguageCodeEnum.fr, element1.Language);
+            Assert.AreEqual(InvalidCharEnum.en_fr, element1.Invalid);
+            Assert.AreEqual("fr",    ((XElement)element1.Untyped.FirstNode).Value);
+            Assert.AreEqual("en-fr", ((XElement)element1.Untyped.LastNode).Value);
+
+            var element2 = new GlobalEnumAttributeType
+            {
+                language = LanguageCodeEnum.fr,
+                invalid  = InvalidCharEnum.en_fr
+            };
+            Assert.AreEqual(LanguageCodeEnum.fr, element2.language);
+            Assert.AreEqual(InvalidCharEnum.en_fr, element2.invalid);
+            Assert.AreEqual("fr",    element2.Untyped.FirstAttribute.Value);
+            Assert.AreEqual("en-fr", element2.Untyped.LastAttribute.Value);
+
+            var element3 = new NestedEnumElementType
+            {
+                Language = NestedEnumElementType.LanguageEnum.fr,
+                Invalid  = NestedEnumElementType.InvalidEnum.en_fr
+            };
+            Assert.AreEqual(NestedEnumElementType.LanguageEnum.fr, element3.Language);
+            Assert.AreEqual(NestedEnumElementType.InvalidEnum.en_fr, element3.Invalid);
+            Assert.AreEqual("fr",    ((XElement)element3.Untyped.FirstNode).Value);
+            Assert.AreEqual("en-fr", ((XElement)element3.Untyped.LastNode).Value);
+
+            var element4 = new NestedEnumAttributeType
+            {
+                language = NestedEnumAttributeType.LanguageEnum.fr,
+                invalid  = NestedEnumAttributeType.InvalidEnum.en_fr
+            };
+            Assert.AreEqual(NestedEnumAttributeType.LanguageEnum.fr, element4.language);
+            Assert.AreEqual(NestedEnumAttributeType.InvalidEnum.en_fr, element4.invalid);
+            Assert.AreEqual("fr",    element4.Untyped.FirstAttribute.Value);
+            Assert.AreEqual("en-fr", element4.Untyped.LastAttribute.Value);
+
+            var element5 = new NestedDerivedEnumAttributeType
+            {
+                language           = NestedEnumAttributeType.LanguageEnum.fr,
+                invalid            = NestedEnumAttributeType.InvalidEnum.en_fr,
+                additionalLanguage = NestedDerivedEnumAttributeType.AdditionalLanguageEnum.rm,
+                additionalInvalid  = NestedDerivedEnumAttributeType.AdditionalInvalidEnum.it_rm,
+
+            };
+            Assert.AreEqual(NestedEnumAttributeType.LanguageEnum.fr, element5.language);
+            Assert.AreEqual(NestedEnumAttributeType.InvalidEnum.en_fr, element5.invalid);
+            Assert.AreEqual("fr",    element5.Untyped.FirstAttribute.Value);
+            Assert.AreEqual("en-fr", element5.Untyped.FirstAttribute.NextAttribute.Value);
+            Assert.AreEqual("rm",    element5.Untyped.FirstAttribute.NextAttribute.NextAttribute.Value);
+            Assert.AreEqual("it-rm", element5.Untyped.FirstAttribute.NextAttribute.NextAttribute.NextAttribute.Value);
         }
     }
 }

--- a/XObjectsTests/EnumsCodeGenTest.cs
+++ b/XObjectsTests/EnumsCodeGenTest.cs
@@ -109,12 +109,15 @@ namespace Xml.Schema.Linq.Tests
             var element1 = new GlobalEnumElementType
             {
                 Language = LanguageCodeEnum.fr,
-                Invalid  = InvalidCharEnum.en_fr
+                Invalid  = InvalidCharEnum.en_fr,
+                Empty    = string.Empty,
             };
             Assert.AreEqual(LanguageCodeEnum.fr, element1.Language);
             Assert.AreEqual(InvalidCharEnum.en_fr, element1.Invalid);
+            Assert.AreEqual(string.Empty, element1.Empty);
+            Assert.AreEqual(0.0m, element1.Version);
             Assert.AreEqual("fr",    ((XElement)element1.Untyped.FirstNode).Value);
-            Assert.AreEqual("en-fr", ((XElement)element1.Untyped.LastNode).Value);
+            Assert.AreEqual("en-fr", ((XElement)element1.Untyped.FirstNode.NextNode).Value);
 
             var element2 = new GlobalEnumAttributeType
             {


### PR DESCRIPTION
### What
Adds support for XML schema enumerations that contain invalid characters. The corresponding C#  `enum`  members are now generated with valid identifiers.

### Why
Previously, when `enum`  values contained invalid characters, the generated C# type fallback was a `string` instead of an `enum`.

### How
For each _invalid_  XML `enumeration` facet , a valid C# identifier is generated (see `EnumFacet`). A mapping between the original (invalid) value and the valid C# `enum` member name is created and used during code generation and runtime (see `EnumFacetMapping`). As a result, the generated properties now use the proper C# `enum` type instead of `string`.