### PR TITLE
Fixed an edge-case bug when reading getter for enum value, updates XObjectsCodeGen version

### DIFF
--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -1,5 +1,13 @@
 # LinqToXsdCore Release Notes
 
+## Version 3.4.15
+Nuget packages:
+* https://www.nuget.org/packages/LinqToXsdCore/3.4.15
+* https://www.nuget.org/packages/XObjectsCore/3.4.15
+  * [#88](https://github.com/mamift/LinqToXsdCore/pull/88).
+    * Fixes a bug which threw an exception when accessing the property getter for an element or attribute whose type is an enum type where the enum value shares the same name with a C# keyword, and thus the string value (ToString) returns a word prefixed with the '@' symbol.
+    * Fixes an issue with publishing new [XObjectsCodeGen](https://www.nuget.org/packages/XObjectsCodeGen) nuget releases.
+
 ## Version 3.4.14
 Nuget packages:
 * https://www.nuget.org/packages/LinqToXsdCore/3.4.14

--- a/Version.props
+++ b/Version.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-    <Version>3.4.14</Version>
+    <Version>3.4.15</Version>
     <VersionSuffix>$(VersionSuffix)</VersionSuffix>
     <Version Condition=" '$(VersionSuffix)' != '' ">$(Version)-$(VersionSuffix)</Version>
   </PropertyGroup>

--- a/XObjectsCode/XObjectsCodeGen.csproj
+++ b/XObjectsCode/XObjectsCodeGen.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;net8.0</TargetFrameworks>
     <Description>The $(MSBuildProjectName) provides code generation facilities, and is consumed by the LinqToXsdCore command line tool; use the LinqToXsdCore tool to generate code, and link to the XObjectsCore nuget package to consume the generated code in your shipping app or library. Original Authors: Microsoft Corporation.</Description>
-    <Version>3.2.6</Version>
     <VersionSuffix>$(VersionSuffix)</VersionSuffix>
     <Version Condition=" '$(VersionSuffix)' != '' ">$(Version)-$(VersionSuffix)</Version>
 	<LangVersion>preview</LangVersion>

--- a/XObjectsCore/API/XTypedServices.cs
+++ b/XObjectsCore/API/XTypedServices.cs
@@ -419,7 +419,15 @@ namespace Xml.Schema.Linq
 
             var strValue  = ParseValue<string>(attribute.Value, attribute.Parent, datatype);
             var enumFacet = typeDef.RestrictionFacets.GetEnumFacet(strValue);
-            return enumFacet != null ? enumFacet.Member : strValue;
+            string enumFacetMemberValue = enumFacet != null ? enumFacet.Member : strValue;
+
+            // some enum values can be C# keywords, and to allow compilation, an '@' symbol is added to the name; 
+            // but when converting back, the '@' symbol needs to be removed so the Enum.Parse method can succeed
+            if (enumFacetMemberValue.Length > 0 && enumFacetMemberValue[0] == '@') {
+                return enumFacetMemberValue.Substring(1, enumFacetMemberValue.Length - 1);
+            }
+
+            return enumFacetMemberValue;
         }
         // Kept for backward compatibility with code generated in previous versions.
         // Current generator does not use this method anymore, as attributes with default properties

--- a/XObjectsCore/API/XTypedServices.cs
+++ b/XObjectsCore/API/XTypedServices.cs
@@ -419,11 +419,17 @@ namespace Xml.Schema.Linq
 
             var strValue  = ParseValue<string>(attribute.Value, attribute.Parent, datatype);
             var enumFacet = typeDef.RestrictionFacets.GetEnumFacet(strValue);
-            string enumFacetMemberValue = enumFacet != null ? enumFacet.Member : strValue;
+            if (enumFacet == null)
+            {
+                return strValue;
+            }
+
+            string enumFacetMemberValue = enumFacet.Member;
 
             // some enum values can be C# keywords, and to allow compilation, an '@' symbol is added to the name; 
             // but when converting back, the '@' symbol needs to be removed so the Enum.Parse method can succeed
-            if (enumFacetMemberValue.Length > 0 && enumFacetMemberValue[0] == '@') {
+            if (enumFacetMemberValue.Length > 0 && enumFacetMemberValue[0] == '@')
+            {
                 return enumFacetMemberValue.Substring(1, enumFacetMemberValue.Length - 1);
             }
 

--- a/XObjectsTests/LinqToXsdConfigurationTests.cs
+++ b/XObjectsTests/LinqToXsdConfigurationTests.cs
@@ -6,7 +6,7 @@ namespace Xml.Schema.Linq.Tests;
 public class LinqToXsdConfigurationTests
 {
     [Test]
-    public void TestSetDefaultVisibility()
+    public void TestSetDefaultVisibility_EnumValueIsInternal()
     {
         var config = new Configuration();
         var ns1 = new Namespace() {

--- a/XObjectsTests/WssApiUseTests.cs
+++ b/XObjectsTests/WssApiUseTests.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Xml.Linq;
 using Microsoft.Schemas.SharePoint;
@@ -66,6 +67,42 @@ namespace Xml.Schema.Linq.Tests
             XAttribute underlyingValue = newParamLocal.Untyped.Attributes(designerTypeAttr).First();
             const string expectedValue = nameof(parametersType.ParameterLocalType.DesignerTypeEnum.DataSourceFieldNames);
             Assert.IsTrue(underlyingValue.Value == expectedValue);
+        }
+
+        /// <summary>
+        /// The purpose of this test is to ensure when getting the value of <see cref="Feature.Hidden"/> (which is an enum type), no exceptions occur when parsing and returning
+        /// the enum string value (which is what happens under the hood with the XObjects API as it invokes <see cref="Enum.Parse(System.Type,System.string)"/>).
+        /// <para>lower case 'false' does clash with C# keyword.</para>
+        /// </summary>
+        [Test]
+        public void TrueFalseTest_EnumValueClashesWithCSharpKeyword()
+        {
+            var newF = new Feature(new FeatureDefinition() {
+                Hidden = TRUEFALSE.@false
+            });
+
+            var isHidden = newF.Hidden;
+
+            Assert.NotNull(isHidden);
+            Assert.AreEqual(isHidden, TRUEFALSE.@false);
+        }
+
+        /// <summary>
+        /// The purpose of this test is to ensure when getting the value of <see cref="Feature.Hidden"/> (which is an enum type), no exceptions occur when parsing and returning
+        /// the enum string value (which is what happens under the hood with the XObjects API as it invokes <see cref="Enum.Parse(System.Type,System.string)"/>).
+        /// <para>Upper case 'TRUE' does not clash with C# keyword.</para>
+        /// </summary>
+        [Test]
+        public void TrueFalseTest_EnumValueIsNotCSharpKeyword()
+        {
+            var newF = new Feature(new FeatureDefinition() {
+                Hidden = TRUEFALSE.TRUE
+            });
+
+            var isHidden = newF.Hidden;
+
+            Assert.NotNull(isHidden);
+            Assert.AreEqual(isHidden, TRUEFALSE.TRUE);
         }
     }
 }


### PR DESCRIPTION
* Fixes a bug which threw an exception when accessing the property getter for an element or attribute whose type is an enum type where the enum value shares the same name with a C# keyword, and thus the string value (ToString) returns a word prefixed with the '@' symbol.
* Fixes an issue with publishing new [XObjectsCodeGen](https://www.nuget.org/packages/XObjectsCodeGen) nuget releases.

v3.4.15